### PR TITLE
feat(api): Update xanderApi.ts for Hermes endpoints (#22)

### DIFF
--- a/docs/hermes/README.md
+++ b/docs/hermes/README.md
@@ -46,6 +46,81 @@ The architecture positions Hermes as the central AI processing unit running in T
 
 4. **Dispatch Integration**: Uses Hermes's built-in MCP protocol to dispatch tasks to the Silas workstation agent.
 
+## API Endpoints
+
+Hermes exposes an OpenRouter-compatible HTTP API for the React Native mobile app to communicate with.
+
+### Default Configuration
+
+| Setting | Value | Description |
+|---------|-------|-------------|
+| **Base URL** | `http://localhost:8080` | Default Hermes port |
+| **Timeout** | 30 seconds | Request timeout |
+
+### Endpoint Reference
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/v1/chat/completions` | POST | OpenRouter-compatible chat completion endpoint |
+| `/health` | GET | Health check endpoint |
+| `/session` | POST | Create new session |
+| `/session/:id` | GET | Get session by ID |
+| `/session/:id` | DELETE | End/delete session |
+
+### Chat Completion Request Format
+
+The chat endpoint accepts OpenRouter-compatible requests:
+
+```typescript
+interface HermesChatRequest {
+  model?: string;           // Optional model override
+  messages: {
+    role: 'user' | 'assistant' | 'system';
+    content: string;
+  }[];
+  max_tokens?: number;      // Maximum response tokens
+  temperature?: number;     // Sampling temperature
+  stream?: boolean;         // Streaming (set to false)
+}
+```
+
+### Chat Completion Response Format
+
+```typescript
+interface HermesChatCompletionResponse {
+  id: string;
+  object: string;
+  created: number;
+  model: string;
+  choices: [{
+    index: number;
+    message: {
+      role: 'assistant';
+      content: string;      // May contain dispatch blocks
+    };
+    finish_reason: string | null;
+  }];
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+}
+```
+
+### Dispatch Block Format
+
+When Xander suggests a task for Silas, the response content includes a dispatch block:
+
+```
+[DISPATCH_SUGGESTED]
+Summary: Brief task description
+Details: Detailed instructions for the task
+[/DISPATCH_SUGGESTED]
+```
+
+The mobile app parses these blocks and displays them separately from the main response.
+
 ## Dependencies
 
 | Dependency | Purpose |

--- a/docs/mobile/architecture.md
+++ b/docs/mobile/architecture.md
@@ -592,20 +592,31 @@ function App() {
 
 #### XanderApi (`src/api/xanderApi.ts`)
 
-Full HTTP client for communicating with the Xander agent running in Termux on the phone.
+Full HTTP client for communicating with the Hermes agent running in Termux on the phone. Uses OpenRouter-compatible chat completion endpoints for AI interactions.
 
 **Purpose:**
-- Send user messages to Xander and receive responses
+- Send user messages to Hermes and receive responses via OpenRouter-compatible endpoint
 - Session management (start, end, retrieve sessions)
+- Conversation history tracking (local)
+- Dispatch block parsing for Silas task suggestions
 - Dispatch functionality to silas-workstation
-- Health check for Xander availability
+- Health check for Hermes availability
 - Handle connection errors gracefully with user-friendly messages
 
 **Configuration:**
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `baseUrl` | `http://localhost:3000` | Xander agent URL |
+| `baseUrl` | `http://localhost:8080` | Hermes agent URL (default Hermes port) |
 | `timeout` | `30000` | Request timeout (ms) |
+
+**Hermes Endpoints:**
+```typescript
+const HERMES_ENDPOINTS = {
+  chat: '/v1/chat/completions', // OpenRouter-compatible chat endpoint
+  health: '/health',            // Health check endpoint
+  session: '/session',          // Session management endpoint
+};
+```
 
 **Constructor:**
 ```typescript
@@ -616,14 +627,21 @@ const api = new XanderApi({ baseUrl?: string, timeout?: number });
 | Method | Returns | Description |
 |--------|---------|-------------|
 | `startSession()` | `Promise<XanderSession>` | Creates a new conversation session. Falls back to local session if server unavailable |
-| `endSession()` | `Promise<void>` | Ends the current session (clears session ID even if server call fails) |
-| `getSession()` | `Promise<XanderSession \| null>` | Retrieves current session data. Returns minimal session if server unreachable |
+| `endSession()` | `Promise<void>` | Ends the current session (clears session ID and conversation history even if server call fails) |
+| `getSession()` | `Promise<XanderSession \| null>` | Retrieves current session data. Returns minimal session with local history if server unreachable |
 | `getSessionId()` | `string \| null` | Returns current session ID synchronously |
 
 **Message Handling Methods:**
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `sendMessage(message)` | `Promise<XanderResponse>` | Sends message to Xander with auto-session creation. Validates message (rejects empty/whitespace). Returns response with optional dispatch suggestions |
+| `sendMessage(message)` | `Promise<XanderResponse>` | Sends message to Hermes via OpenRouter chat completion. Auto-creates session, maintains conversation history, parses dispatch blocks. Returns clean response with dispatch metadata |
+| `sendChatCompletion(request)` | `Promise<HermesChatResponse>` | Raw OpenRouter-compatible chat completion request for advanced use cases |
+
+**Conversation History Methods:**
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `getConversationHistory()` | `HermesMessage[]` | Returns a copy of the current conversation history |
+| `clearHistory()` | `void` | Clears conversation history without ending the session (useful for topic changes) |
 
 **Dispatch Methods:**
 | Method | Returns | Description |
@@ -634,11 +652,121 @@ const api = new XanderApi({ baseUrl?: string, timeout?: number });
 **Health & Configuration Methods:**
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `healthCheck()` | `Promise<boolean>` | Detects Xander availability via /health endpoint |
+| `healthCheck()` | `Promise<boolean>` | Detects Hermes availability via /health endpoint |
 | `getBaseUrl()` | `string` | Returns the current base URL |
 | `setBaseUrl(url)` | `void` | Updates the base URL (useful for testing or configuration changes) |
 
-**Core Types:**
+**Hermes-Specific Types:**
+```typescript
+/**
+ * Message format for Hermes/OpenRouter chat API
+ */
+interface HermesMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+}
+
+/**
+ * Request body for Hermes chat completions (OpenRouter format)
+ */
+interface HermesChatRequest {
+  model?: string;
+  messages: HermesMessage[];
+  max_tokens?: number;
+  temperature?: number;
+  stream?: boolean;
+}
+
+/**
+ * Choice from Hermes/OpenRouter response
+ */
+interface HermesChoice {
+  index: number;
+  message: HermesMessage;
+  finish_reason: string | null;
+}
+
+/**
+ * Raw response from Hermes/OpenRouter chat completions endpoint
+ */
+interface HermesChatCompletionResponse {
+  id: string;
+  object: string;
+  created: number;
+  model: string;
+  choices: HermesChoice[];
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+}
+
+/**
+ * Parsed dispatch information from response content
+ */
+interface HermesDispatch {
+  suggested: boolean;
+  summary?: string;
+  details?: string;
+}
+
+/**
+ * Processed chat response with parsed dispatch info
+ */
+interface HermesChatResponse {
+  response: string;        // Clean response without dispatch block
+  dispatch?: HermesDispatch;
+  rawContent: string;      // Original response with dispatch block
+}
+
+/**
+ * Session data from Hermes
+ */
+interface HermesSessionResponse {
+  sessionId: string;
+  messages: HermesMessage[];
+}
+```
+
+**Dispatch Block Parsing:**
+
+Hermes responses may contain dispatch blocks when Xander suggests a task for Silas. The API automatically parses and removes these blocks from the displayed response.
+
+**Format:**
+```
+[DISPATCH_SUGGESTED]
+Summary: Brief task description
+Details: Detailed task instructions
+[/DISPATCH_SUGGESTED]
+```
+
+**Parsing Functions:**
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `parseDispatchBlock(content)` | `(content: string) => HermesDispatch` | Extracts dispatch info from response content. Returns `{ suggested: true, summary, details }` if found, `{ suggested: false }` otherwise |
+| `removeDispatchBlock(content)` | `(content: string) => string` | Removes dispatch block from content for clean display. Normalizes whitespace |
+
+**Example Dispatch Block:**
+```
+User: "Can you research the best coffee grinders under $200?"
+
+Hermes Response:
+"That sounds like a good research task for Silas - he can dig deep into reviews and comparisons.
+
+[DISPATCH_SUGGESTED]
+Summary: Research best coffee grinders under $200
+Details: Find and compare coffee grinders under $200. Look at user reviews, grind consistency, durability, and value. Provide top 3-5 recommendations with pros/cons.
+[/DISPATCH_SUGGESTED]"
+
+After parsing:
+- response: "That sounds like a good research task for Silas..."
+- dispatch.suggested: true
+- dispatch.summary: "Research best coffee grinders under $200"
+- dispatch.details: "Find and compare coffee grinders..."
+```
+
+**Core Types (OpenRouter-compatible):**
 ```typescript
 interface Message {
   role: 'user' | 'assistant';
@@ -694,6 +822,7 @@ interface XanderResponse {
     researchPerformed?: boolean;
     suggestDispatch?: boolean;
     dispatchSummary?: string;
+    dispatchDetails?: string;  // New: detailed dispatch information
     [key: string]: unknown;
   };
 }
@@ -716,37 +845,55 @@ The API converts axios errors to user-friendly `XanderApiError` objects:
 
 | Error Code | Condition | Message |
 |------------|-----------|---------|
-| `CONNECTION_REFUSED` | Cannot connect to Xander | "Cannot connect to Xander. Make sure Xander is running in Termux." |
-| `TIMEOUT` | Request timed out | "Request to Xander timed out. Please try again." |
-| `NETWORK_ERROR` | Network unreachable | "Network error. Check your connection and make sure Xander is running." |
+| `CONNECTION_REFUSED` | Cannot connect to Hermes | "Cannot connect to Hermes. Make sure Hermes is running in Termux." |
+| `TIMEOUT` | Request timed out | "Request to Hermes timed out. Please try again." |
+| `NETWORK_ERROR` | Network unreachable | "Network error. Check your connection and make sure Hermes is running." |
 | `BAD_REQUEST` | HTTP 400 | Server-provided message or "Invalid request. Please check your input." |
 | `UNAUTHORIZED` | HTTP 401 | "Authentication required." |
 | `NOT_FOUND` | HTTP 404 | "The requested resource was not found." |
-| `SERVER_ERROR` | HTTP 500 | "Xander encountered an internal error. Please try again." |
-| `SERVICE_UNAVAILABLE` | HTTP 503 | "Xander is temporarily unavailable. Please try again later." |
+| `SERVER_ERROR` | HTTP 500 | "Hermes encountered an internal error. Please try again." |
+| `SERVICE_UNAVAILABLE` | HTTP 503 | "Hermes is temporarily unavailable. Please try again later." |
 | `INVALID_MESSAGE` | Empty message sent | "Message cannot be empty" |
+| `INVALID_RESPONSE` | No response from Hermes | "No response from Hermes" |
 
 **Graceful Fallbacks:**
 - `startSession()`: Creates local session (`local-session-{timestamp}`) when server unavailable
-- `getSession()`: Returns minimal session object when server unreachable
-- `endSession()`: Clears local session ID even if server call fails
+- `getSession()`: Returns minimal session object with local conversation history when server unreachable
+- `endSession()`: Clears local session ID and conversation history even if server call fails
 
-**Status:** ✅ Complete
+**Status:** ✅ Complete (Updated for Hermes integration)
 
 **Usage Examples:**
 
-Basic conversation:
+Basic conversation with Hermes:
 ```tsx
 import { xanderApi } from '@/api';
 
 // Send a message (auto-creates session if needed)
 const response = await xanderApi.sendMessage("Hello Xander");
-console.log(response.message);
+console.log(response.message); // Clean response without dispatch block
 
 // Check if dispatch was suggested
 if (response.metadata?.suggestDispatch) {
   console.log('Dispatch suggestion:', response.metadata.dispatchSummary);
+  console.log('Details:', response.metadata.dispatchDetails);
 }
+```
+
+Conversation history management:
+```tsx
+import { xanderApi } from '@/api';
+
+// Send multiple messages (history is maintained)
+await xanderApi.sendMessage("Hello!");
+await xanderApi.sendMessage("What's the weather like?");
+
+// Get conversation history
+const history = xanderApi.getConversationHistory();
+console.log('Messages in history:', history.length);
+
+// Clear history to start a new topic without new session
+xanderApi.clearHistory();
 ```
 
 Session management:
@@ -760,8 +907,30 @@ console.log('Session ID:', session.sessionId);
 // Get current session
 const currentSession = await xanderApi.getSession();
 
-// End session when done
+// End session when done (clears history)
 await xanderApi.endSession();
+```
+
+Advanced: Raw chat completion:
+```tsx
+import { xanderApi, HermesChatRequest } from '@/api';
+
+// Send raw OpenRouter-compatible request
+const request: HermesChatRequest = {
+  messages: [
+    { role: 'system', content: 'You are a helpful assistant.' },
+    { role: 'user', content: 'Explain quantum computing briefly.' }
+  ],
+  temperature: 0.7,
+  max_tokens: 500
+};
+
+const result = await xanderApi.sendChatCompletion(request);
+console.log('Response:', result.response);
+console.log('Raw content:', result.rawContent);
+if (result.dispatch?.suggested) {
+  console.log('Dispatch suggested:', result.dispatch.summary);
+}
 ```
 
 Dispatching work to Silas:
@@ -787,14 +956,14 @@ Health check and configuration:
 ```tsx
 import { xanderApi } from '@/api';
 
-// Check if Xander is available
+// Check if Hermes is available
 const isAvailable = await xanderApi.healthCheck();
 if (!isAvailable) {
-  console.log('Xander is not running');
+  console.log('Hermes is not running');
 }
 
 // Update base URL for testing
-xanderApi.setBaseUrl('http://192.168.1.100:3000');
+xanderApi.setBaseUrl('http://192.168.1.100:8080');
 console.log('Current URL:', xanderApi.getBaseUrl());
 ```
 
@@ -804,9 +973,30 @@ import XanderApi from '@/api';
 
 // Create custom instance with different config
 const customApi = new XanderApi({
-  baseUrl: 'http://custom-host:3000',
+  baseUrl: 'http://custom-host:8080',
   timeout: 60000 // 60 seconds
 });
+```
+
+Parsing dispatch blocks manually:
+```tsx
+import { parseDispatchBlock, removeDispatchBlock } from '@/api';
+
+const content = `Here's my response.
+
+[DISPATCH_SUGGESTED]
+Summary: Research task
+Details: Research the topic thoroughly
+[/DISPATCH_SUGGESTED]`;
+
+const dispatch = parseDispatchBlock(content);
+if (dispatch.suggested) {
+  console.log('Summary:', dispatch.summary);
+  console.log('Details:', dispatch.details);
+}
+
+const cleanContent = removeDispatchBlock(content);
+console.log('Display:', cleanContent); // "Here's my response."
 ```
 
 ---
@@ -1298,4 +1488,4 @@ export const useNewStore = create<NewStoreState>((set) => ({
 
 ---
 
-*Last updated: Phase 5 - Audio Focus Management - Native Module (Android audio focus management with native Kotlin module, useAudioFocus hook, and platform-aware behavior)*
+*Last updated: Hermes Integration - Updated XanderApi to use Hermes agent (port 8080) with OpenRouter-compatible chat completions, dispatch block parsing, conversation history management, and new methods (getConversationHistory, sendChatCompletion, clearHistory)*

--- a/mobile/src/api/__tests__/xanderApi.test.ts
+++ b/mobile/src/api/__tests__/xanderApi.test.ts
@@ -1,11 +1,15 @@
 /**
  * Unit tests for XanderApi
- * Tests HTTP client functionality for Xander agent communication
+ * Tests HTTP client functionality for Hermes agent communication
  */
 
 import axios from 'axios';
-import { XanderApi } from '../xanderApi';
-import type { XanderApiError } from '../xanderApi';
+import {
+  XanderApi,
+  parseDispatchBlock,
+  removeDispatchBlock,
+} from '../xanderApi';
+import type { XanderApiError, HermesDispatch } from '../xanderApi';
 
 // Get access to the mock axios module
 const mockAxios = axios as jest.Mocked<typeof axios>;
@@ -32,11 +36,11 @@ describe('XanderApi', () => {
   });
 
   describe('Constructor', () => {
-    it('should create an axios instance with default config', () => {
+    it('should create an axios instance with default config (port 8080)', () => {
       new XanderApi();
       expect(mockAxios.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseURL: 'http://localhost:3000',
+          baseURL: 'http://localhost:8080',
           timeout: 30000,
           headers: {
             'Content-Type': 'application/json',
@@ -47,12 +51,12 @@ describe('XanderApi', () => {
 
     it('should use custom config when provided', () => {
       new XanderApi({
-        baseUrl: 'http://custom:8080',
+        baseUrl: 'http://custom:9000',
         timeout: 60000,
       });
       expect(mockAxios.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          baseURL: 'http://custom:8080',
+          baseURL: 'http://custom:9000',
           timeout: 60000,
         })
       );
@@ -67,9 +71,8 @@ describe('XanderApi', () => {
     it('should return session ID after starting a session', async () => {
       mockInstance.post.mockResolvedValueOnce({
         data: {
-          id: 'test-session-123',
+          sessionId: 'test-session-123',
           messages: [],
-          createdAt: '2024-01-01T00:00:00Z',
         },
       });
 
@@ -78,8 +81,54 @@ describe('XanderApi', () => {
     });
   });
 
+  describe('getConversationHistory', () => {
+    it('should return empty array when no messages', () => {
+      expect(api.getConversationHistory()).toEqual([]);
+    });
+
+    it('should return copy of conversation history after sending messages', async () => {
+      // Start a session
+      mockInstance.post.mockResolvedValueOnce({
+        data: {
+          sessionId: 'history-test-session',
+          messages: [],
+        },
+      });
+      await api.startSession();
+
+      // Send a message
+      mockInstance.post.mockResolvedValueOnce({
+        data: {
+          id: 'completion-1',
+          object: 'chat.completion',
+          created: Date.now(),
+          model: 'claude-3',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: 'Hello! How can I help?',
+              },
+              finish_reason: 'stop',
+            },
+          ],
+        },
+      });
+
+      await api.sendMessage('Hello');
+
+      const history = api.getConversationHistory();
+      expect(history).toHaveLength(2);
+      expect(history[0].role).toBe('user');
+      expect(history[0].content).toBe('Hello');
+      expect(history[1].role).toBe('assistant');
+      expect(history[1].content).toBe('Hello! How can I help?');
+    });
+  });
+
   describe('healthCheck', () => {
-    it('should return true when Xander is available', async () => {
+    it('should return true when Hermes is available', async () => {
       mockInstance.get.mockResolvedValueOnce({ data: { status: 'ok' } });
 
       const result = await api.healthCheck();
@@ -88,7 +137,7 @@ describe('XanderApi', () => {
       expect(mockInstance.get).toHaveBeenCalledWith('/health');
     });
 
-    it('should return false when Xander is unavailable', async () => {
+    it('should return false when Hermes is unavailable', async () => {
       mockInstance.get.mockRejectedValueOnce({
         code: 'ECONNREFUSED',
         message: 'Connection refused',
@@ -115,30 +164,27 @@ describe('XanderApi', () => {
     it('should create a new session and store session ID', async () => {
       mockInstance.post.mockResolvedValueOnce({
         data: {
-          id: 'new-session-456',
+          sessionId: 'new-session-456',
           messages: [],
-          createdAt: '2024-01-01T12:00:00Z',
         },
       });
 
       const session = await api.startSession();
 
-      expect(mockInstance.post).toHaveBeenCalledWith('/sessions');
+      expect(mockInstance.post).toHaveBeenCalledWith('/session');
       expect(session.sessionId).toBe('new-session-456');
       expect(session.messages).toEqual([]);
-      expect(session.createdAt).toBe('2024-01-01T12:00:00Z');
       expect(api.getSessionId()).toBe('new-session-456');
     });
 
     it('should convert messages to XanderMessage format with timestamps', async () => {
       mockInstance.post.mockResolvedValueOnce({
         data: {
-          id: 'session-with-messages',
+          sessionId: 'session-with-messages',
           messages: [
             { role: 'user', content: 'Hello' },
             { role: 'assistant', content: 'Hi there!' },
           ],
-          createdAt: '2024-01-01T12:00:00Z',
         },
       });
 
@@ -162,6 +208,41 @@ describe('XanderApi', () => {
       expect(session.messages).toEqual([]);
       expect(api.getSessionId()).toMatch(/^local-session-/);
     });
+
+    it('should clear conversation history on new session', async () => {
+      // Start first session
+      mockInstance.post.mockResolvedValueOnce({
+        data: { sessionId: 'session-1', messages: [] },
+      });
+      await api.startSession();
+
+      // Send a message
+      mockInstance.post.mockResolvedValueOnce({
+        data: {
+          id: 'completion-1',
+          object: 'chat.completion',
+          created: Date.now(),
+          model: 'claude-3',
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: 'Hello!' },
+              finish_reason: 'stop',
+            },
+          ],
+        },
+      });
+      await api.sendMessage('Hi');
+      expect(api.getConversationHistory().length).toBe(2);
+
+      // Start new session
+      mockInstance.post.mockResolvedValueOnce({
+        data: { sessionId: 'session-2', messages: [] },
+      });
+      await api.startSession();
+
+      expect(api.getConversationHistory()).toEqual([]);
+    });
   });
 
   describe('endSession', () => {
@@ -169,9 +250,8 @@ describe('XanderApi', () => {
       // First start a session
       mockInstance.post.mockResolvedValueOnce({
         data: {
-          id: 'session-to-end',
+          sessionId: 'session-to-end',
           messages: [],
-          createdAt: '2024-01-01T00:00:00Z',
         },
       });
       await api.startSession();
@@ -180,7 +260,9 @@ describe('XanderApi', () => {
       mockInstance.delete.mockResolvedValueOnce({ data: {} });
       await api.endSession();
 
-      expect(mockInstance.delete).toHaveBeenCalledWith('/sessions/session-to-end');
+      expect(mockInstance.delete).toHaveBeenCalledWith(
+        '/session/session-to-end'
+      );
       expect(api.getSessionId()).toBeNull();
     });
 
@@ -195,9 +277,8 @@ describe('XanderApi', () => {
       // Start a session
       mockInstance.post.mockResolvedValueOnce({
         data: {
-          id: 'session-error',
+          sessionId: 'session-error',
           messages: [],
-          createdAt: '2024-01-01T00:00:00Z',
         },
       });
       await api.startSession();
@@ -211,6 +292,7 @@ describe('XanderApi', () => {
       await api.endSession();
 
       expect(api.getSessionId()).toBeNull();
+      expect(api.getConversationHistory()).toEqual([]);
     });
   });
 
@@ -225,9 +307,8 @@ describe('XanderApi', () => {
       // Start a session
       mockInstance.post.mockResolvedValueOnce({
         data: {
-          id: 'get-session-test',
+          sessionId: 'get-session-test',
           messages: [],
-          createdAt: '2024-01-01T00:00:00Z',
         },
       });
       await api.startSession();
@@ -235,29 +316,47 @@ describe('XanderApi', () => {
       // Get the session
       mockInstance.get.mockResolvedValueOnce({
         data: {
-          id: 'get-session-test',
+          sessionId: 'get-session-test',
           messages: [{ role: 'user', content: 'Test message' }],
-          createdAt: '2024-01-01T00:00:00Z',
         },
       });
 
       const session = await api.getSession();
 
-      expect(mockInstance.get).toHaveBeenCalledWith('/sessions/get-session-test');
+      expect(mockInstance.get).toHaveBeenCalledWith(
+        '/session/get-session-test'
+      );
       expect(session?.sessionId).toBe('get-session-test');
       expect(session?.messages).toHaveLength(1);
     });
 
-    it('should return minimal session on server error', async () => {
+    it('should return minimal session with local history on server error', async () => {
       // Start a session
       mockInstance.post.mockResolvedValueOnce({
         data: {
-          id: 'session-fallback',
+          sessionId: 'session-fallback',
           messages: [],
-          createdAt: '2024-01-01T00:00:00Z',
         },
       });
       await api.startSession();
+
+      // Send a message to have some history
+      mockInstance.post.mockResolvedValueOnce({
+        data: {
+          id: 'completion-1',
+          object: 'chat.completion',
+          created: Date.now(),
+          model: 'claude-3',
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: 'Response' },
+              finish_reason: 'stop',
+            },
+          ],
+        },
+      });
+      await api.sendMessage('Hello');
 
       // Get fails
       mockInstance.get.mockRejectedValueOnce({
@@ -268,36 +367,57 @@ describe('XanderApi', () => {
       const session = await api.getSession();
 
       expect(session?.sessionId).toBe('session-fallback');
-      expect(session?.messages).toEqual([]);
+      expect(session?.messages).toHaveLength(2);
     });
   });
 
   describe('sendMessage', () => {
-    it('should send a message and return response', async () => {
+    it('should send a message using OpenRouter format and return response', async () => {
       // Start a session first
       mockInstance.post.mockResolvedValueOnce({
         data: {
-          id: 'chat-session',
+          sessionId: 'chat-session',
           messages: [],
-          createdAt: '2024-01-01T00:00:00Z',
         },
       });
       await api.startSession();
 
-      // Send a message
-      mockInstance.post.mockResolvedValueOnce({
-        data: {
-          sessionId: 'chat-session',
-          response: 'Hello! How can I help you?',
-          suggestDispatch: false,
-        },
+      // Capture what was sent to the chat endpoint
+      let capturedRequest: unknown = null;
+      mockInstance.post.mockImplementationOnce((url: string, data: unknown) => {
+        capturedRequest = JSON.parse(JSON.stringify(data)); // Deep copy at call time
+        return Promise.resolve({
+          data: {
+            id: 'completion-1',
+            object: 'chat.completion',
+            created: Date.now(),
+            model: 'claude-3',
+            choices: [
+              {
+                index: 0,
+                message: {
+                  role: 'assistant',
+                  content: 'Hello! How can I help you?',
+                },
+                finish_reason: 'stop',
+              },
+            ],
+          },
+        });
       });
 
       const result = await api.sendMessage('Hello');
 
-      expect(mockInstance.post).toHaveBeenCalledWith('/chat', {
-        sessionId: 'chat-session',
-        message: 'Hello',
+      // Verify it was called with the chat endpoint with correct request format
+      expect(mockInstance.post).toHaveBeenNthCalledWith(
+        2,
+        '/v1/chat/completions',
+        expect.anything()
+      );
+      // Verify the captured request (at call time, before response processing)
+      expect(capturedRequest).toEqual({
+        messages: [{ role: 'user', content: 'Hello' }],
+        stream: false,
       });
       expect(result.message).toBe('Hello! How can I help you?');
       expect(result.sessionId).toBe('chat-session');
@@ -307,23 +427,34 @@ describe('XanderApi', () => {
       // Mock session creation
       mockInstance.post.mockResolvedValueOnce({
         data: {
-          id: 'auto-session',
+          sessionId: 'auto-session',
           messages: [],
-          createdAt: '2024-01-01T00:00:00Z',
         },
       });
 
       // Mock message response
       mockInstance.post.mockResolvedValueOnce({
         data: {
-          sessionId: 'auto-session',
-          response: 'Response after auto-start',
+          id: 'completion-1',
+          object: 'chat.completion',
+          created: Date.now(),
+          model: 'claude-3',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: 'Response after auto-start',
+              },
+              finish_reason: 'stop',
+            },
+          ],
         },
       });
 
       const result = await api.sendMessage('Test message');
 
-      expect(mockInstance.post).toHaveBeenCalledWith('/sessions');
+      expect(mockInstance.post).toHaveBeenCalledWith('/session');
       expect(result.message).toBe('Response after auto-start');
     });
 
@@ -331,26 +462,39 @@ describe('XanderApi', () => {
       // Start a session
       mockInstance.post.mockResolvedValueOnce({
         data: {
-          id: 'trim-session',
+          sessionId: 'trim-session',
           messages: [],
-          createdAt: '2024-01-01T00:00:00Z',
         },
       });
       await api.startSession();
 
-      // Send message
-      mockInstance.post.mockResolvedValueOnce({
-        data: {
-          sessionId: 'trim-session',
-          response: 'Response',
-        },
+      // Capture what was sent to the chat endpoint
+      let capturedRequest: unknown = null;
+      mockInstance.post.mockImplementationOnce((url: string, data: unknown) => {
+        capturedRequest = JSON.parse(JSON.stringify(data)); // Deep copy at call time
+        return Promise.resolve({
+          data: {
+            id: 'completion-1',
+            object: 'chat.completion',
+            created: Date.now(),
+            model: 'claude-3',
+            choices: [
+              {
+                index: 0,
+                message: { role: 'assistant', content: 'Response' },
+                finish_reason: 'stop',
+              },
+            ],
+          },
+        });
       });
 
       await api.sendMessage('  Hello World  ');
 
-      expect(mockInstance.post).toHaveBeenCalledWith('/chat', {
-        sessionId: 'trim-session',
-        message: 'Hello World',
+      // Verify the captured request has trimmed message
+      expect(capturedRequest).toEqual({
+        messages: [{ role: 'user', content: 'Hello World' }],
+        stream: false,
       });
     });
 
@@ -372,13 +516,12 @@ describe('XanderApi', () => {
       );
     });
 
-    it('should include dispatch suggestion in metadata', async () => {
+    it('should parse and include dispatch suggestion in metadata', async () => {
       // Start a session
       mockInstance.post.mockResolvedValueOnce({
         data: {
-          id: 'dispatch-session',
+          sessionId: 'dispatch-session',
           messages: [],
-          createdAt: '2024-01-01T00:00:00Z',
         },
       });
       await api.startSession();
@@ -386,10 +529,25 @@ describe('XanderApi', () => {
       // Send message with dispatch suggestion
       mockInstance.post.mockResolvedValueOnce({
         data: {
-          sessionId: 'dispatch-session',
-          response: 'I can help with that task.',
-          suggestDispatch: true,
-          dispatchSummary: 'Create a new feature',
+          id: 'completion-1',
+          object: 'chat.completion',
+          created: Date.now(),
+          model: 'claude-3',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: `I can help with that task.
+
+[DISPATCH_SUGGESTED]
+Summary: Create a new feature
+Details: Build a new feature for the application with tests.
+[/DISPATCH_SUGGESTED]`,
+              },
+              finish_reason: 'stop',
+            },
+          ],
         },
       });
 
@@ -397,37 +555,71 @@ describe('XanderApi', () => {
 
       expect(result.metadata?.suggestDispatch).toBe(true);
       expect(result.metadata?.dispatchSummary).toBe('Create a new feature');
+      expect(result.metadata?.dispatchDetails).toBe(
+        'Build a new feature for the application with tests.'
+      );
+      expect(result.message).toBe('I can help with that task.');
     });
 
-    it('should update session ID if server provides different one', async () => {
-      // Start with local session (server error)
-      mockInstance.post.mockRejectedValueOnce({
-        code: 'ECONNREFUSED',
-        message: 'Connection refused',
+    it('should accumulate conversation history', async () => {
+      // Start a session
+      mockInstance.post.mockResolvedValueOnce({
+        data: { sessionId: 'history-session', messages: [] },
       });
       await api.startSession();
-      expect(api.getSessionId()).toMatch(/^local-session-/);
 
-      // Now server responds with real session
+      // First message
       mockInstance.post.mockResolvedValueOnce({
         data: {
-          sessionId: 'server-session-new',
-          response: 'Connected!',
+          id: 'completion-1',
+          object: 'chat.completion',
+          created: Date.now(),
+          model: 'claude-3',
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: 'Hi!' },
+              finish_reason: 'stop',
+            },
+          ],
         },
       });
-
       await api.sendMessage('Hello');
 
-      expect(api.getSessionId()).toBe('server-session-new');
+      // Second message should include history (but NOT include the second assistant response yet)
+      mockInstance.post.mockResolvedValueOnce({
+        data: {
+          id: 'completion-2',
+          object: 'chat.completion',
+          created: Date.now(),
+          model: 'claude-3',
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: 'Great!' },
+              finish_reason: 'stop',
+            },
+          ],
+        },
+      });
+      await api.sendMessage('How are you?');
+
+      // The third call (2 session + 2 chat) should have included the accumulated history BEFORE the call
+      // Since we're checking after the fact, verify the conversation history state instead
+      const history = api.getConversationHistory();
+      expect(history).toHaveLength(4);
+      expect(history[0]).toEqual({ role: 'user', content: 'Hello' });
+      expect(history[1]).toEqual({ role: 'assistant', content: 'Hi!' });
+      expect(history[2]).toEqual({ role: 'user', content: 'How are you?' });
+      expect(history[3]).toEqual({ role: 'assistant', content: 'Great!' });
     });
 
     it('should propagate server errors', async () => {
       // Start a session
       mockInstance.post.mockResolvedValueOnce({
         data: {
-          id: 'error-session',
+          sessionId: 'error-session',
           messages: [],
-          createdAt: '2024-01-01T00:00:00Z',
         },
       });
       await api.startSession();
@@ -441,15 +633,121 @@ describe('XanderApi', () => {
 
       await expect(api.sendMessage('Test')).rejects.toEqual(serverError);
     });
+
+    it('should throw error when no choices in response', async () => {
+      // Start a session
+      mockInstance.post.mockResolvedValueOnce({
+        data: { sessionId: 'empty-session', messages: [] },
+      });
+      await api.startSession();
+
+      // Response with no choices
+      mockInstance.post.mockResolvedValueOnce({
+        data: {
+          id: 'completion-empty',
+          object: 'chat.completion',
+          created: Date.now(),
+          model: 'claude-3',
+          choices: [],
+        },
+      });
+
+      await expect(api.sendMessage('Test')).rejects.toEqual(
+        expect.objectContaining({
+          code: 'INVALID_RESPONSE',
+          message: 'No response from Hermes',
+        })
+      );
+    });
+  });
+
+  describe('sendChatCompletion', () => {
+    it('should send raw chat completion request', async () => {
+      mockInstance.post.mockResolvedValueOnce({
+        data: {
+          id: 'completion-raw',
+          object: 'chat.completion',
+          created: Date.now(),
+          model: 'claude-3',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: 'Raw response',
+              },
+              finish_reason: 'stop',
+            },
+          ],
+        },
+      });
+
+      const result = await api.sendChatCompletion({
+        messages: [{ role: 'user', content: 'Test' }],
+      });
+
+      expect(mockInstance.post).toHaveBeenCalledWith('/v1/chat/completions', {
+        messages: [{ role: 'user', content: 'Test' }],
+      });
+      expect(result.response).toBe('Raw response');
+      expect(result.rawContent).toBe('Raw response');
+      expect(result.dispatch).toBeUndefined();
+    });
+
+    it('should include dispatch info when present', async () => {
+      mockInstance.post.mockResolvedValueOnce({
+        data: {
+          id: 'completion-dispatch',
+          object: 'chat.completion',
+          created: Date.now(),
+          model: 'claude-3',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: `Here's the response.
+
+[DISPATCH_SUGGESTED]
+Summary: Task summary
+Details: Task details here
+[/DISPATCH_SUGGESTED]`,
+              },
+              finish_reason: 'stop',
+            },
+          ],
+        },
+      });
+
+      const result = await api.sendChatCompletion({
+        messages: [{ role: 'user', content: 'Test' }],
+      });
+
+      expect(result.response).toBe("Here's the response.");
+      expect(result.dispatch?.suggested).toBe(true);
+      expect(result.dispatch?.summary).toBe('Task summary');
+      expect(result.dispatch?.details).toBe('Task details here');
+    });
   });
 
   describe('dispatch', () => {
-    it('should dispatch work to silas-workstation', async () => {
+    it('should dispatch work via chat completion', async () => {
       mockInstance.post.mockResolvedValueOnce({
         data: {
-          success: true,
-          taskId: 'task-123',
-          message: 'Task dispatched successfully',
+          id: 'dispatch-completion',
+          object: 'chat.completion',
+          created: Date.now(),
+          model: 'claude-3',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: 'Task has been dispatched to Silas.',
+              },
+              finish_reason: 'stop',
+            },
+          ],
         },
       });
 
@@ -459,14 +757,21 @@ describe('XanderApi', () => {
         details: 'Detailed description of the feature',
       });
 
-      expect(mockInstance.post).toHaveBeenCalledWith('/dispatch', {
-        sessionId: 'session-456',
-        summary: 'Create new feature',
-        details: 'Detailed description of the feature',
-      });
+      expect(mockInstance.post).toHaveBeenCalledWith(
+        '/v1/chat/completions',
+        expect.objectContaining({
+          messages: [
+            expect.objectContaining({
+              role: 'user',
+              content: expect.stringContaining('Create new feature'),
+            }),
+          ],
+          stream: false,
+        })
+      );
       expect(result.success).toBe(true);
-      expect(result.taskId).toBe('task-123');
-      expect(result.message).toBe('Task dispatched successfully');
+      expect(result.taskId).toMatch(/^task-/);
+      expect(result.message).toBe('Task has been dispatched to Silas.');
     });
 
     it('should throw error on dispatch failure', async () => {
@@ -491,9 +796,8 @@ describe('XanderApi', () => {
       // Start a session
       mockInstance.post.mockResolvedValueOnce({
         data: {
-          id: 'legacy-session',
+          sessionId: 'legacy-session',
           messages: [],
-          createdAt: '2024-01-01T00:00:00Z',
         },
       });
       await api.startSession();
@@ -501,36 +805,47 @@ describe('XanderApi', () => {
       // Dispatch
       mockInstance.post.mockResolvedValueOnce({
         data: {
-          success: true,
-          taskId: 'legacy-task',
-          message: 'OK',
+          id: 'dispatch-completion',
+          object: 'chat.completion',
+          created: Date.now(),
+          model: 'claude-3',
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: 'OK' },
+              finish_reason: 'stop',
+            },
+          ],
         },
       });
 
       const result = await api.dispatchToSilas('Create a new widget');
 
       expect(result).toBe(true);
-      expect(mockInstance.post).toHaveBeenCalledWith('/dispatch', {
-        sessionId: 'legacy-session',
-        summary: 'Create a new widget',
-        details: 'Create a new widget',
-      });
+      expect(mockInstance.post).toHaveBeenCalledWith(
+        '/v1/chat/completions',
+        expect.objectContaining({
+          messages: [
+            expect.objectContaining({
+              content: expect.stringContaining('Create a new widget'),
+            }),
+          ],
+        })
+      );
     });
 
     it('should return false when no session exists', async () => {
       const result = await api.dispatchToSilas('Test dispatch');
 
       expect(result).toBe(false);
-      expect(mockInstance.post).not.toHaveBeenCalledWith('/dispatch', expect.anything());
     });
 
     it('should return false on dispatch error', async () => {
       // Start a session
       mockInstance.post.mockResolvedValueOnce({
         data: {
-          id: 'error-dispatch-session',
+          sessionId: 'error-dispatch-session',
           messages: [],
-          createdAt: '2024-01-01T00:00:00Z',
         },
       });
       await api.startSession();
@@ -567,6 +882,180 @@ describe('XanderApi', () => {
       expect(mockInstance.defaults.baseURL).toBe('http://newurl:5000');
     });
   });
+
+  describe('clearHistory', () => {
+    it('should clear conversation history', async () => {
+      // Start a session
+      mockInstance.post.mockResolvedValueOnce({
+        data: { sessionId: 'clear-session', messages: [] },
+      });
+      await api.startSession();
+
+      // Send a message
+      mockInstance.post.mockResolvedValueOnce({
+        data: {
+          id: 'completion-1',
+          object: 'chat.completion',
+          created: Date.now(),
+          model: 'claude-3',
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: 'Hello!' },
+              finish_reason: 'stop',
+            },
+          ],
+        },
+      });
+      await api.sendMessage('Hi');
+
+      expect(api.getConversationHistory().length).toBe(2);
+
+      // Clear history
+      api.clearHistory();
+
+      expect(api.getConversationHistory()).toEqual([]);
+      expect(api.getSessionId()).toBe('clear-session'); // Session should remain
+    });
+  });
+});
+
+describe('Dispatch Block Parsing', () => {
+  describe('parseDispatchBlock', () => {
+    it('should parse valid dispatch block', () => {
+      const content = `Here is my response.
+
+[DISPATCH_SUGGESTED]
+Summary: Research best coffee grinders
+Details: Find and compare coffee grinders under $200.
+[/DISPATCH_SUGGESTED]`;
+
+      const result = parseDispatchBlock(content);
+
+      expect(result.suggested).toBe(true);
+      expect(result.summary).toBe('Research best coffee grinders');
+      expect(result.details).toBe(
+        'Find and compare coffee grinders under $200.'
+      );
+    });
+
+    it('should handle multi-line details', () => {
+      const content = `I can help with that.
+
+[DISPATCH_SUGGESTED]
+Summary: Create new feature
+Details: Build a new feature with the following:
+- Feature A
+- Feature B
+- Feature C
+[/DISPATCH_SUGGESTED]`;
+
+      const result = parseDispatchBlock(content);
+
+      expect(result.suggested).toBe(true);
+      expect(result.summary).toBe('Create new feature');
+      expect(result.details).toContain('Feature A');
+      expect(result.details).toContain('Feature B');
+      expect(result.details).toContain('Feature C');
+    });
+
+    it('should return suggested=false when no dispatch block', () => {
+      const content = 'This is just a regular response without any dispatch.';
+
+      const result = parseDispatchBlock(content);
+
+      expect(result.suggested).toBe(false);
+      expect(result.summary).toBeUndefined();
+      expect(result.details).toBeUndefined();
+    });
+
+    it('should handle case insensitive tags', () => {
+      const content = `Response here.
+
+[dispatch_suggested]
+Summary: Test task
+Details: Test details
+[/dispatch_suggested]`;
+
+      const result = parseDispatchBlock(content);
+
+      expect(result.suggested).toBe(true);
+      expect(result.summary).toBe('Test task');
+    });
+
+    it('should handle Windows-style line endings', () => {
+      const content =
+        'Response.\r\n\r\n[DISPATCH_SUGGESTED]\r\nSummary: Task\r\nDetails: Details here\r\n[/DISPATCH_SUGGESTED]';
+
+      const result = parseDispatchBlock(content);
+
+      expect(result.suggested).toBe(true);
+      expect(result.summary).toBe('Task');
+      expect(result.details).toBe('Details here');
+    });
+  });
+
+  describe('removeDispatchBlock', () => {
+    it('should remove dispatch block and clean content', () => {
+      const content = `Here is my response.
+
+[DISPATCH_SUGGESTED]
+Summary: Task summary
+Details: Task details
+[/DISPATCH_SUGGESTED]`;
+
+      const result = removeDispatchBlock(content);
+
+      expect(result).toBe('Here is my response.');
+      expect(result).not.toContain('DISPATCH_SUGGESTED');
+    });
+
+    it('should handle content with no dispatch block', () => {
+      const content = 'Just a regular response.';
+
+      const result = removeDispatchBlock(content);
+
+      expect(result).toBe('Just a regular response.');
+    });
+
+    it('should handle content with dispatch block in middle', () => {
+      const content = `Start of response.
+
+[DISPATCH_SUGGESTED]
+Summary: Task
+Details: Details
+[/DISPATCH_SUGGESTED]
+
+End of response.`;
+
+      const result = removeDispatchBlock(content);
+
+      expect(result).toBe('Start of response.\n\nEnd of response.');
+    });
+
+    it('should handle multiple dispatch blocks', () => {
+      const content = `First part.
+
+[DISPATCH_SUGGESTED]
+Summary: Task 1
+Details: Details 1
+[/DISPATCH_SUGGESTED]
+
+Middle part.
+
+[DISPATCH_SUGGESTED]
+Summary: Task 2
+Details: Details 2
+[/DISPATCH_SUGGESTED]
+
+Last part.`;
+
+      const result = removeDispatchBlock(content);
+
+      expect(result).toBe('First part.\n\nMiddle part.\n\nLast part.');
+      expect(result).not.toContain('DISPATCH_SUGGESTED');
+    });
+  });
 });
 
 describe('XanderApi Error Handling', () => {
@@ -578,10 +1067,6 @@ describe('XanderApi Error Handling', () => {
     api = new XanderApi();
     mockInstance = getMockInstance();
   });
-
-  // Note: Error conversion is tested via the response interceptor
-  // which is set up in createApiClient. Since we mock axios,
-  // we test the error scenarios through the API methods themselves.
 
   describe('Network errors', () => {
     it('should handle connection refused', async () => {

--- a/mobile/src/api/xanderApi.ts
+++ b/mobile/src/api/xanderApi.ts
@@ -1,27 +1,111 @@
 /**
- * xanderApi - HTTP client for Xander agent
+ * xanderApi - HTTP client for Xander agent via Hermes
  *
  * This module provides the HTTP client for communicating with the
- * Xander agent running in Termux on the phone.
+ * Hermes agent running in Termux on the phone.
  *
  * Features:
- * - Send user messages to Xander
- * - Receive Xander's responses
+ * - Send user messages to Hermes (OpenRouter-compatible chat endpoint)
+ * - Receive responses with dispatch block parsing
  * - Session management (start, end, get session)
  * - Handle connection errors gracefully
  * - Dispatch functionality to silas-workstation
- * - Health check for Xander availability
+ * - Health check for Hermes availability
  *
- * The Xander agent runs locally in Termux at http://localhost:3000
+ * The Hermes agent runs locally in Termux at http://localhost:8080
  */
 
 import axios, { AxiosInstance, AxiosError } from 'axios';
 
 // Configuration
-const DEFAULT_BASE_URL = 'http://localhost:3000';
+const DEFAULT_BASE_URL = 'http://localhost:8080';
 const DEFAULT_TIMEOUT = 30000; // 30 seconds
 
-// Types
+// Hermes/OpenRouter endpoint paths
+const HERMES_ENDPOINTS = {
+  chat: '/v1/chat/completions', // OpenRouter compatible
+  health: '/health',
+  session: '/session',
+};
+
+// ====================
+// Hermes-specific Types
+// ====================
+
+/**
+ * Message format for Hermes/OpenRouter chat API
+ */
+export interface HermesMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+}
+
+/**
+ * Request body for Hermes chat completions (OpenRouter format)
+ */
+export interface HermesChatRequest {
+  model?: string;
+  messages: HermesMessage[];
+  max_tokens?: number;
+  temperature?: number;
+  stream?: boolean;
+}
+
+/**
+ * Choice from Hermes/OpenRouter response
+ */
+export interface HermesChoice {
+  index: number;
+  message: HermesMessage;
+  finish_reason: string | null;
+}
+
+/**
+ * Raw response from Hermes/OpenRouter chat completions endpoint
+ */
+export interface HermesChatCompletionResponse {
+  id: string;
+  object: string;
+  created: number;
+  model: string;
+  choices: HermesChoice[];
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+}
+
+/**
+ * Parsed dispatch information from response content
+ */
+export interface HermesDispatch {
+  suggested: boolean;
+  summary?: string;
+  details?: string;
+}
+
+/**
+ * Processed chat response with parsed dispatch info
+ */
+export interface HermesChatResponse {
+  response: string;
+  dispatch?: HermesDispatch;
+  rawContent: string;
+}
+
+/**
+ * Session data from Hermes
+ */
+export interface HermesSessionResponse {
+  sessionId: string;
+  messages: HermesMessage[];
+}
+
+// ====================
+// Legacy Types (backward compatibility)
+// ====================
+
 export interface Message {
   role: 'user' | 'assistant';
   content: string;
@@ -52,7 +136,6 @@ export interface DispatchResponse {
   message: string;
 }
 
-// Legacy types for backward compatibility
 export interface XanderMessage {
   role: 'user' | 'assistant';
   content: string;
@@ -74,6 +157,7 @@ export interface XanderResponse {
     researchPerformed?: boolean;
     suggestDispatch?: boolean;
     dispatchSummary?: string;
+    dispatchDetails?: string;
     [key: string]: unknown;
   };
 }
@@ -89,6 +173,52 @@ export interface XanderApiError {
   details?: unknown;
 }
 
+// ====================
+// Dispatch Block Parsing
+// ====================
+
+/**
+ * Parse [DISPATCH_SUGGESTED] blocks from response content
+ *
+ * Format:
+ * [DISPATCH_SUGGESTED]
+ * Summary: ...
+ * Details: ...
+ * [/DISPATCH_SUGGESTED]
+ */
+export function parseDispatchBlock(content: string): HermesDispatch {
+  const dispatchRegex =
+    /\[DISPATCH_SUGGESTED\]\s*(?:\n|\r\n)?Summary:\s*(.+?)(?:\n|\r\n)Details:\s*([\s\S]*?)\[\/DISPATCH_SUGGESTED\]/i;
+
+  const match = content.match(dispatchRegex);
+
+  if (match) {
+    return {
+      suggested: true,
+      summary: match[1].trim(),
+      details: match[2].trim(),
+    };
+  }
+
+  return { suggested: false };
+}
+
+/**
+ * Remove dispatch block from response content for clean display
+ */
+export function removeDispatchBlock(content: string): string {
+  const dispatchRegex =
+    /\s*\[DISPATCH_SUGGESTED\][\s\S]*?\[\/DISPATCH_SUGGESTED\]\s*/gi;
+  // Replace dispatch blocks and then normalize multiple newlines
+  const result = content.replace(dispatchRegex, '\n\n');
+  // Clean up excessive newlines and trim
+  return result.replace(/\n{3,}/g, '\n\n').trim();
+}
+
+// ====================
+// Error Handling
+// ====================
+
 /**
  * Convert AxiosError to user-friendly XanderApiError
  */
@@ -98,27 +228,29 @@ function convertAxiosError(error: AxiosError): XanderApiError {
     if (error.code === 'ECONNREFUSED') {
       return {
         code: 'CONNECTION_REFUSED',
-        message: 'Cannot connect to Xander. Make sure Xander is running in Termux.',
+        message:
+          'Cannot connect to Hermes. Make sure Hermes is running in Termux.',
         details: error.message,
       };
     }
     if (error.code === 'ETIMEDOUT' || error.code === 'ECONNABORTED') {
       return {
         code: 'TIMEOUT',
-        message: 'Request to Xander timed out. Please try again.',
+        message: 'Request to Hermes timed out. Please try again.',
         details: error.message,
       };
     }
     if (error.code === 'ENETUNREACH' || error.code === 'ENOTFOUND') {
       return {
         code: 'NETWORK_ERROR',
-        message: 'Network error. Check your connection and make sure Xander is running.',
+        message:
+          'Network error. Check your connection and make sure Hermes is running.',
         details: error.message,
       };
     }
     return {
       code: error.code ?? 'NETWORK_ERROR',
-      message: 'Unable to reach Xander. Check your connection.',
+      message: 'Unable to reach Hermes. Check your connection.',
       details: error.message,
     };
   }
@@ -130,7 +262,8 @@ function convertAxiosError(error: AxiosError): XanderApiError {
   if (status === 400) {
     return {
       code: 'BAD_REQUEST',
-      message: (data?.message as string) ?? 'Invalid request. Please check your input.',
+      message:
+        (data?.message as string) ?? 'Invalid request. Please check your input.',
       details: data,
     };
   }
@@ -151,14 +284,14 @@ function convertAxiosError(error: AxiosError): XanderApiError {
   if (status === 500) {
     return {
       code: 'SERVER_ERROR',
-      message: 'Xander encountered an internal error. Please try again.',
+      message: 'Hermes encountered an internal error. Please try again.',
       details: data,
     };
   }
   if (status === 503) {
     return {
       code: 'SERVICE_UNAVAILABLE',
-      message: 'Xander is temporarily unavailable. Please try again later.',
+      message: 'Hermes is temporarily unavailable. Please try again later.',
       details: data,
     };
   }
@@ -170,8 +303,12 @@ function convertAxiosError(error: AxiosError): XanderApiError {
   };
 }
 
+// ====================
+// API Client Factory
+// ====================
+
 /**
- * Create an axios instance configured for Xander API
+ * Create an axios instance configured for Hermes API
  */
 function createApiClient(config?: XanderApiConfig): AxiosInstance {
   const baseURL = config?.baseUrl ?? DEFAULT_BASE_URL;
@@ -214,18 +351,23 @@ function createApiClient(config?: XanderApiConfig): AxiosInstance {
   return client;
 }
 
+// ====================
+// XanderApi Class
+// ====================
+
 /**
- * XanderApi class for interacting with the Xander agent
+ * XanderApi class for interacting with the Hermes agent
  *
  * Provides full HTTP client functionality for:
  * - Session management
- * - Message sending/receiving
- * - Dispatch to silas-workstation
+ * - Message sending/receiving via OpenRouter-compatible endpoint
+ * - Dispatch block parsing for Silas tasks
  * - Health checking
  */
 export class XanderApi {
   private client: AxiosInstance;
   private currentSessionId: string | null = null;
+  private conversationHistory: HermesMessage[] = [];
 
   constructor(config?: XanderApiConfig) {
     this.client = createApiClient(config);
@@ -239,11 +381,18 @@ export class XanderApi {
   }
 
   /**
-   * Check if Xander agent is available
+   * Get the conversation history
+   */
+  getConversationHistory(): HermesMessage[] {
+    return [...this.conversationHistory];
+  }
+
+  /**
+   * Check if Hermes agent is available
    */
   async healthCheck(): Promise<boolean> {
     try {
-      await this.client.get('/health');
+      await this.client.get(HERMES_ENDPOINTS.health);
       console.log('[XanderApi] Health check passed');
       return true;
     } catch (error) {
@@ -257,27 +406,35 @@ export class XanderApi {
    */
   async startSession(): Promise<XanderSession> {
     try {
-      const response = await this.client.post<Session>('/sessions');
+      const response = await this.client.post<HermesSessionResponse>(
+        HERMES_ENDPOINTS.session
+      );
       const session = response.data;
 
-      this.currentSessionId = session.id;
-      console.log('[XanderApi] Session started:', session.id);
+      this.currentSessionId = session.sessionId;
+      this.conversationHistory = [];
+      console.log('[XanderApi] Session started:', session.sessionId);
 
       // Convert to XanderSession format
       return {
-        sessionId: session.id,
+        sessionId: session.sessionId,
         messages: session.messages.map((msg) => ({
-          ...msg,
+          role: msg.role as 'user' | 'assistant',
+          content: msg.content,
           timestamp: new Date().toISOString(),
         })),
-        createdAt: session.createdAt,
-        updatedAt: session.createdAt,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
       };
     } catch (error) {
       // If we get an error, create a local session as fallback
       const sessionId = `local-session-${Date.now()}`;
       this.currentSessionId = sessionId;
-      console.warn('[XanderApi] Failed to start remote session, using local:', error);
+      this.conversationHistory = [];
+      console.warn(
+        '[XanderApi] Failed to start remote session, using local:',
+        error
+      );
 
       return {
         sessionId,
@@ -298,12 +455,15 @@ export class XanderApi {
     }
 
     try {
-      await this.client.delete(`/sessions/${this.currentSessionId}`);
+      await this.client.delete(
+        `${HERMES_ENDPOINTS.session}/${this.currentSessionId}`
+      );
       console.log('[XanderApi] Session ended:', this.currentSessionId);
     } catch (error) {
       console.warn('[XanderApi] Failed to end session on server:', error);
     } finally {
       this.currentSessionId = null;
+      this.conversationHistory = [];
     }
   }
 
@@ -316,26 +476,31 @@ export class XanderApi {
     }
 
     try {
-      const response = await this.client.get<Session>(
-        `/sessions/${this.currentSessionId}`
+      const response = await this.client.get<HermesSessionResponse>(
+        `${HERMES_ENDPOINTS.session}/${this.currentSessionId}`
       );
       const session = response.data;
 
       return {
-        sessionId: session.id,
+        sessionId: session.sessionId,
         messages: session.messages.map((msg) => ({
-          ...msg,
+          role: msg.role as 'user' | 'assistant',
+          content: msg.content,
           timestamp: new Date().toISOString(),
         })),
-        createdAt: session.createdAt,
-        updatedAt: session.createdAt,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
       };
     } catch (error) {
       console.warn('[XanderApi] Failed to get session:', error);
       // Return a minimal session if server is unreachable
       return {
         sessionId: this.currentSessionId,
-        messages: [],
+        messages: this.conversationHistory.map((msg) => ({
+          role: msg.role as 'user' | 'assistant',
+          content: msg.content,
+          timestamp: new Date().toISOString(),
+        })),
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
       };
@@ -343,7 +508,8 @@ export class XanderApi {
   }
 
   /**
-   * Send a message to Xander and get a response
+   * Send a message to Hermes and get a response
+   * Uses OpenRouter-compatible chat completions endpoint
    * Automatically starts a session if none exists
    */
   async sendMessage(message: string): Promise<XanderResponse> {
@@ -362,26 +528,53 @@ export class XanderApi {
     }
 
     try {
-      const response = await this.client.post<SendMessageResponse>('/chat', {
-        sessionId: this.currentSessionId,
-        message: message.trim(),
-      });
+      // Add user message to conversation history
+      const userMessage: HermesMessage = {
+        role: 'user',
+        content: message.trim(),
+      };
+      this.conversationHistory.push(userMessage);
+
+      // Build chat request in OpenRouter format
+      const chatRequest: HermesChatRequest = {
+        messages: this.conversationHistory,
+        stream: false,
+      };
+
+      const response = await this.client.post<HermesChatCompletionResponse>(
+        HERMES_ENDPOINTS.chat,
+        chatRequest
+      );
 
       const data = response.data;
+      const assistantMessage = data.choices[0]?.message;
 
-      // Update session ID if server provides a different one
-      if (data.sessionId && data.sessionId !== this.currentSessionId) {
-        this.currentSessionId = data.sessionId;
+      if (!assistantMessage) {
+        throw {
+          code: 'INVALID_RESPONSE',
+          message: 'No response from Hermes',
+        } as XanderApiError;
       }
+
+      // Add assistant message to conversation history
+      this.conversationHistory.push({
+        role: 'assistant',
+        content: assistantMessage.content,
+      });
+
+      // Parse dispatch block from response
+      const dispatch = parseDispatchBlock(assistantMessage.content);
+      const cleanResponse = removeDispatchBlock(assistantMessage.content);
 
       console.log('[XanderApi] Message sent successfully');
 
       return {
-        message: data.response,
-        sessionId: data.sessionId,
+        message: cleanResponse,
+        sessionId: this.currentSessionId!,
         metadata: {
-          suggestDispatch: data.suggestDispatch,
-          dispatchSummary: data.dispatchSummary,
+          suggestDispatch: dispatch.suggested,
+          dispatchSummary: dispatch.summary,
+          dispatchDetails: dispatch.details,
         },
       };
     } catch (error) {
@@ -392,19 +585,84 @@ export class XanderApi {
   }
 
   /**
+   * Send a raw chat completion request (for advanced use)
+   */
+  async sendChatCompletion(
+    request: HermesChatRequest
+  ): Promise<HermesChatResponse> {
+    try {
+      const response = await this.client.post<HermesChatCompletionResponse>(
+        HERMES_ENDPOINTS.chat,
+        request
+      );
+
+      const data = response.data;
+      const assistantMessage = data.choices[0]?.message;
+
+      if (!assistantMessage) {
+        throw {
+          code: 'INVALID_RESPONSE',
+          message: 'No response from Hermes',
+        } as XanderApiError;
+      }
+
+      const dispatch = parseDispatchBlock(assistantMessage.content);
+      const cleanResponse = removeDispatchBlock(assistantMessage.content);
+
+      return {
+        response: cleanResponse,
+        dispatch: dispatch.suggested ? dispatch : undefined,
+        rawContent: assistantMessage.content,
+      };
+    } catch (error) {
+      const apiError = error as XanderApiError;
+      console.error('[XanderApi] Chat completion failed:', apiError);
+      throw apiError;
+    }
+  }
+
+  /**
    * Dispatch work to Silas (workstation)
    * Used to send tasks to the workstation agent for processing
    */
   async dispatch(request: DispatchRequest): Promise<DispatchResponse> {
     try {
-      const response = await this.client.post<DispatchResponse>(
-        '/dispatch',
-        request
+      // For Hermes, dispatch is done via MCP protocol
+      // We construct a message that triggers the dispatch
+      const dispatchMessage = `Please dispatch this task to Silas:
+
+Summary: ${request.summary}
+Details: ${request.details}
+
+Session: ${request.sessionId}`;
+
+      const chatRequest: HermesChatRequest = {
+        messages: [
+          {
+            role: 'user',
+            content: dispatchMessage,
+          },
+        ],
+        stream: false,
+      };
+
+      const response = await this.client.post<HermesChatCompletionResponse>(
+        HERMES_ENDPOINTS.chat,
+        chatRequest
       );
 
-      console.log('[XanderApi] Dispatch successful:', response.data.taskId);
+      // Generate a task ID for tracking
+      const taskId = `task-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 
-      return response.data;
+      console.log('[XanderApi] Dispatch successful:', taskId);
+
+      return {
+        success: true,
+        taskId,
+        message:
+          response.data.choices[0]?.message?.content ||
+          'Task dispatched successfully',
+      };
     } catch (error) {
       const apiError = error as XanderApiError;
       console.error('[XanderApi] Dispatch failed:', apiError);
@@ -448,6 +706,14 @@ export class XanderApi {
   setBaseUrl(url: string): void {
     this.client.defaults.baseURL = url;
     console.log('[XanderApi] Base URL updated:', url);
+  }
+
+  /**
+   * Clear conversation history (for new topic without new session)
+   */
+  clearHistory(): void {
+    this.conversationHistory = [];
+    console.log('[XanderApi] Conversation history cleared');
   }
 }
 

--- a/plans/hermes-architecture-overhaul.md
+++ b/plans/hermes-architecture-overhaul.md
@@ -1,0 +1,353 @@
+# Hermes Architecture Overhaul Plan
+
+## Executive Summary
+
+This document outlines the architectural changes needed to transition the Xander Voice App from a custom Express/Node.js backend (xander-engine) to **Hermes Agent** as the underlying AI backend. The React Native mobile app will remain as the voice UI entry point, communicating with Hermes running in Termux on the Android device.
+
+**Key Decision**: Keep React Native UI as entry point, replace xander-engine with Hermes Agent.
+
+---
+
+## Problem Statement
+
+### What Went Wrong
+
+The original implementation deviated from the intended architecture:
+
+| Aspect | Intended (Hermes) | Implemented (Wrong) |
+|--------|-------------------|---------------------|
+| AI Backend | Hermes Agent in Termux | Custom Express/Node.js server |
+| LLM Provider | OpenRouter/Local models | Direct Anthropic Cloud API |
+| Voice Handling | Could leverage Hermes voice | Custom React Native voice |
+| Memory | Hermes persistent memory | Session-only memory |
+| MCP Dispatch | Hermes built-in MCP | Custom dispatch route |
+
+### Root Cause
+
+The original plan (`plans/xander-voice-app-plan.md`) was underspecified. It described:
+- "Xander (Phone Agent - Termux)" without specifying Hermes
+- Generic tech stack without naming the AI agent framework
+- Phase 6 "Conversation Engine" without referencing Hermes
+
+The implementer built a custom solution instead of integrating the existing Hermes Agent.
+
+---
+
+## New Architecture
+
+### High-Level Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        ANDROID PHONE                             │
+│                                                                  │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │ React Native App (mobile/)                                │   │
+│  │                                                           │   │
+│  │ • Voice UI (VoiceButton, status display)                  │   │
+│  │ • expo-speech-recognition (STT) - speech to text          │   │
+│  │ • expo-speech (TTS) - text to speech                      │   │
+│  │ • Audio focus management                                  │   │
+│  │ • Gesture controls (interrupt, steer, etc.)               │   │
+│  │                                                           │   │
+│  │ ┌─────────────────────────────────────────────────────┐   │   │
+│  │ │ xanderApi.ts - HTTP client to Hermes                │   │   │
+│  │ │ • POST /chat - send text, get response              │   │   │
+│  │ │ • Session management                                │   │   │
+│  │ └─────────────────────────────────────────────────────┘   │   │
+│  └────────────────────────────────────────────────────────┬──┘   │
+│                                                           │      │
+│                                          HTTP (localhost) │      │
+│                                                           ▼      │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │ HERMES AGENT (Termux)                                     │   │
+│  │                                                           │   │
+│  │ Features:                                                 │   │
+│  │ • Conversational AI with personality                      │   │
+│  │ • OpenRouter integration (200+ LLM models)                │   │
+│  │ • OR local model support (llama.cpp, etc.)                │   │
+│  │ • Persistent memory (skills, user profiles)               │   │
+│  │ • MCP server mode for dispatch                            │   │
+│  │ • Web search & research tools                             │   │
+│  │ • Self-improving capabilities                             │   │
+│  │                                                           │   │
+│  │ Endpoints (MCP Server Mode):                              │   │
+│  │ • Chat/conversation                                       │   │
+│  │ • Memory operations                                       │   │
+│  │ • Tool invocation                                         │   │
+│  │ • Dispatch to Silas                                       │   │
+│  └────────────────────────────────────────────────────────┬──┘   │
+│                                                           │      │
+└───────────────────────────────────────────────────────────│──────┘
+                                                            │
+                                               MCP Protocol │
+                                                            ▼
+                           ┌──────────────────────────────────────┐
+                           │ SILAS (Workstation Admin)            │
+                           │                                      │
+                           │ • Receives dispatched work           │
+                           │ • Creates detailed plans             │
+                           │ • Queues tasks for execution         │
+                           │ • Async execution                    │
+                           └──────────────────────────────────────┘
+```
+
+### Data Flow
+
+```
+User speaks → React Native STT → Text
+    ↓
+Text → HTTP POST to Hermes (localhost:PORT)
+    ↓
+Hermes processes with LLM + memory + tools
+    ↓
+Response text ← Hermes
+    ↓
+React Native TTS ← Text → User hears
+```
+
+---
+
+## Component Changes
+
+### 1. Remove: xander-engine/
+
+**Status**: DELETE ENTIRELY
+
+The entire `xander-engine/` directory should be removed:
+- `xander-engine/src/server.ts` - Custom Express server
+- `xander-engine/src/services/llmClient.ts` - Direct Anthropic API calls
+- `xander-engine/src/services/sessionManager.ts` - Custom session handling
+- `xander-engine/src/routes/*` - Custom routes
+- All tests, config, etc.
+
+**Reason**: Hermes provides all this functionality natively.
+
+### 2. Add: Hermes Agent Setup
+
+**New Component**: Hermes installation and configuration in Termux
+
+```bash
+# Termux setup
+pkg install python
+pip install hermes-agent  # or from source
+# OR
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+```
+
+**Configuration needed**:
+- `~/.hermes/config.yaml` - Hermes configuration
+- Environment variables for OpenRouter API key
+- MCP server configuration for Silas dispatch
+
+### 3. Modify: mobile/src/api/xanderApi.ts
+
+**Status**: UPDATE to call Hermes instead of xander-engine
+
+Current implementation calls:
+- `POST /session/start`
+- `POST /chat`
+- `POST /session/end`
+- `POST /dispatch`
+
+New implementation should call Hermes endpoints (MCP server mode or custom wrapper).
+
+### 4. Keep: React Native Voice Components
+
+**Status**: KEEP with minor updates
+
+These components remain valuable:
+- `mobile/src/hooks/useVoice.ts` - STT handling
+- `mobile/src/hooks/useSpeech.ts` - TTS handling
+- `mobile/src/hooks/useAudioFocus.ts` - Audio focus
+- `mobile/src/components/ui/VoiceButton.tsx` - UI
+- `mobile/native-modules/android/` - Audio focus native module
+
+Minor updates may be needed for error handling and Hermes integration.
+
+### 5. Keep: Plans and Documentation
+
+**Status**: UPDATE
+
+- `plans/xander-voice-app-plan.md` - Update to reference Hermes
+- `docs/` - Update architecture docs
+
+---
+
+## Migration Tasks
+
+### Phase A: Hermes Setup (New)
+
+| Task | Description | Estimate |
+|------|-------------|----------|
+| A.1 | Install Hermes in Termux | 30 min |
+| A.2 | Configure Hermes (config.yaml) | 30 min |
+| A.3 | Set up OpenRouter API key | 15 min |
+| A.4 | Configure Hermes personality (Xander prompt) | 30 min |
+| A.5 | Test Hermes CLI conversation | 15 min |
+| A.6 | Configure Hermes MCP server mode | 1 hour |
+| A.7 | Test Hermes HTTP/MCP endpoints | 30 min |
+
+**Subtotal**: ~3.5 hours
+
+### Phase B: xander-engine Removal
+
+| Task | Description | Estimate |
+|------|-------------|----------|
+| B.1 | Document current API interface | 15 min |
+| B.2 | Remove xander-engine directory | 5 min |
+| B.3 | Update workspace configuration | 15 min |
+| B.4 | Update CI/CD to remove xander-engine tests | 15 min |
+
+**Subtotal**: ~1 hour
+
+### Phase C: API Integration Update
+
+| Task | Description | Estimate |
+|------|-------------|----------|
+| C.1 | Update xanderApi.ts for Hermes endpoints | 1 hour |
+| C.2 | Update session management for Hermes | 30 min |
+| C.3 | Update dispatch logic for Hermes MCP | 30 min |
+| C.4 | Add error handling for Hermes | 30 min |
+| C.5 | Update API tests | 1 hour |
+
+**Subtotal**: ~3.5 hours
+
+### Phase D: Integration Testing
+
+| Task | Description | Estimate |
+|------|-------------|----------|
+| D.1 | Test voice → Hermes → voice flow | 1 hour |
+| D.2 | Test conversation memory | 30 min |
+| D.3 | Test dispatch to Silas | 30 min |
+| D.4 | Test audio focus with Hermes | 30 min |
+| D.5 | End-to-end testing | 1 hour |
+
+**Subtotal**: ~3.5 hours
+
+### Phase E: Documentation Update
+
+| Task | Description | Estimate |
+|------|-------------|----------|
+| E.1 | Update xander-voice-app-plan.md | 30 min |
+| E.2 | Update architecture docs | 30 min |
+| E.3 | Create Hermes setup guide | 30 min |
+| E.4 | Update README files | 15 min |
+
+**Subtotal**: ~2 hours
+
+---
+
+## Total Estimated Effort
+
+| Phase | Hours |
+|-------|-------|
+| Phase A: Hermes Setup | 3.5 |
+| Phase B: xander-engine Removal | 1.0 |
+| Phase C: API Integration Update | 3.5 |
+| Phase D: Integration Testing | 3.5 |
+| Phase E: Documentation Update | 2.0 |
+| **Total** | **~13.5 hours** |
+
+---
+
+## GitHub Issues to Update
+
+### Issues to Close/Modify
+
+| Issue # | Title | Action |
+|---------|-------|--------|
+| #7 | Phase 6: Conversation Engine | CLOSE - Replace with Hermes |
+| #8 | Phase 7: Light Research | MODIFY - Hermes has built-in research |
+| #9 | Phase 8: Dispatcher | MODIFY - Use Hermes MCP dispatch |
+| #18 | PR: xander-engine | CLOSE - Being replaced |
+
+### New Issues to Create
+
+| Title | Description |
+|-------|-------------|
+| Hermes Setup in Termux | Install and configure Hermes Agent |
+| Configure Hermes for Xander Personality | Set up Xander system prompt and behavior |
+| Hermes MCP Server Configuration | Configure MCP mode for API access |
+| Update xanderApi.ts for Hermes | Modify API client to call Hermes |
+| Remove xander-engine | Clean removal of obsolete code |
+| Integration Testing with Hermes | Test full voice → Hermes → voice flow |
+| Update Documentation for Hermes | Revise all docs to reflect new architecture |
+
+---
+
+## Risk Assessment
+
+### Technical Risks
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Hermes Termux compatibility issues | High | Medium | Test on device before full migration |
+| Hermes API differs from expected | Medium | Medium | Review Hermes docs thoroughly |
+| Performance issues on mobile | High | Low | Use OpenRouter with fast models |
+| Memory constraints in Termux | Medium | Medium | Use cloud LLM, not local |
+
+### Resource Risks
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| OpenRouter API costs | Medium | Medium | Monitor usage, set limits |
+| Learning curve for Hermes | Low | Medium | Start with simple config |
+
+---
+
+## Success Criteria
+
+- [ ] Hermes running in Termux on device
+- [ ] React Native app successfully calls Hermes
+- [ ] Conversation flows naturally with memory
+- [ ] Dispatch to Silas works via MCP
+- [ ] xander-engine completely removed
+- [ ] All documentation updated
+- [ ] GitHub issues reflect new architecture
+
+---
+
+## Next Steps
+
+1. **Approve this plan** - Confirm architecture direction
+2. **Update GitHub issues** - Close obsolete, create new
+3. **Install Hermes** - Set up in Termux
+4. **Migrate API client** - Update xanderApi.ts
+5. **Test end-to-end** - Verify full flow
+6. **Document** - Update all docs
+
+---
+
+## Appendix: Hermes Configuration Example
+
+```yaml
+# ~/.hermes/config.yaml (example)
+model_provider: openrouter
+model_name: anthropic/claude-3.5-sonnet  # or other models
+
+system_prompt: |
+  You are Xander, a conversational AI companion running on a phone. 
+  Your primary job is to be great to talk to - like a smart friend 
+  the user can brainstorm with, especially while driving.
+  
+  ## Your Personality
+  - Natural and conversational - not robotic or formal
+  - Listen actively and ask good follow-up questions
+  - Think WITH the user, not FOR them
+  - Be concise since responses will be spoken aloud (TTS)
+  - Warm, helpful, and engaged without being overly enthusiastic
+
+mcp:
+  enabled: true
+  port: 3000
+  
+memory:
+  enabled: true
+  persist: true
+```
+
+---
+
+*Document created: 2025-01-XX*
+*Last updated: 2025-01-XX*


### PR DESCRIPTION
## Summary

Updates the React Native API client (`mobile/src/api/xanderApi.ts`) to communicate with Hermes Agent instead of the custom xander-engine Express server.

Closes #22

## Changes Made

### API Client Updates (`mobile/src/api/xanderApi.ts`)

1. **Updated Base URL** - Changed from `http://localhost:3000` to `http://localhost:8080` (Hermes default port)

2. **Added `HERMES_ENDPOINTS` object** with OpenRouter-compatible paths:
   - `chat: '/v1/chat/completions'` (OpenRouter format)
   - `health: '/health'`
   - `session: '/session'`

3. **Added New Hermes Types:**
   - `HermesMessage` - Message format with role and content
   - `HermesChatRequest` - OpenRouter chat completion request format
   - `HermesChoice` - Response choice with message and metadata
   - `HermesChatCompletionResponse` - Full OpenRouter response format
   - `HermesDispatch` - Dispatch suggestion structure
   - `HermesChatResponse` - Processed response with dispatch info
   - `HermesSessionResponse` - Session with message history

4. **Implemented Dispatch Block Parsing:**
   - `parseDispatchBlock(content)` - Parses `[DISPATCH_SUGGESTED]...[/DISPATCH_SUGGESTED]` blocks from response content
   - `removeDispatchBlock(content)` - Removes dispatch blocks from content while preserving surrounding text

5. **Added New Methods:**
   - `getConversationHistory()` - Returns a copy of the conversation history
   - `sendChatCompletion(request)` - Raw OpenRouter-compatible chat completion
   - `clearHistory()` - Clears the conversation history

6. **Updated Existing Methods:**
   - `sendMessage()` now uses OpenRouter format and parses dispatch blocks
   - All methods use the new `HERMES_ENDPOINTS` paths
   - Maintained full backward compatibility with existing types and methods

### Unit Tests (`mobile/src/api/__tests__/xanderApi.test.ts`)

- Updated all endpoint expectations to use new Hermes paths
- Added comprehensive tests for `parseDispatchBlock` and `removeDispatchBlock`
- Fixed mock timing issues using deep copy pattern for request capture
- All 52 xanderApi tests pass

### Documentation

- **`docs/mobile/architecture.md`** - Updated XanderApi section with new endpoints, types, methods, and usage examples
- **`docs/hermes/README.md`** - Added API Endpoints section with endpoint reference, request/response formats, and dispatch block documentation

## Test Results

- All 196 mobile tests pass
- No regressions introduced

## Commits

1. `feat(api): update xanderApi for Hermes endpoints (#22)` - Implementation
2. `docs: update API documentation for Hermes integration (#22)` - Documentation