### PR TITLE
docs: Fix Hermes installation documentation (pip install is incorrect)

### DIFF
--- a/docs/hermes/setup.md
+++ b/docs/hermes/setup.md
@@ -39,17 +39,38 @@ python --version
 
 ### Step 2: Install Hermes Agent
 
-**Option A: Install via pip (Recommended)**
+**⚠️ Important:** Hermes is NOT on PyPI - must install from source.
 
-```bash
-pip install hermes-agent
-```
-
-**Option B: Install from source (Latest features)**
+**Option A: Official Install Script (Recommended)**
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+source ~/.bashrc
 ```
+
+**Option B: Manual Termux Installation**
+
+```bash
+# Install uv (modern Python package manager)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+source ~/.bashrc
+
+# Clone and install
+git clone https://github.com/NousResearch/hermes-agent.git
+cd hermes-agent
+python -m pip install -e '.[termux]' -c constraints-termux.txt
+```
+
+**Option C: Using setup-hermes.sh Script**
+
+```bash
+git clone https://github.com/NousResearch/hermes-agent.git
+cd hermes-agent
+./setup-hermes.sh
+./hermes  # Auto-detects venv
+```
+
+> **⚠️ Termux Note:** Use `[termux]` extra, NOT `[all]`. The `[all]` extra pulls Android-incompatible dependencies (ctranslate2, onnxruntime). Apply `constraints-termux.txt` for tested versions.
 
 ### Step 3: Create Hermes Home Directory
 
@@ -170,14 +191,19 @@ hermes chat "What kind of work do I do?"
 
 ## Troubleshooting
 
+### "hermes-agent not found on PyPI"
+
+Hermes is NOT published to PyPI. You must install from source using one of the methods in Step 2 above.
+
 ### "Command not found: hermes"
 
 ```bash
-# Check if hermes is installed
-pip show hermes-agent
-
 # Add to PATH
 export PATH="$HOME/.local/bin:$PATH"
+
+# Make permanent
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
 ```
 
 ### "API key not found"
@@ -251,10 +277,12 @@ Run with:
 
 ## Updating Hermes
 
-### Update via pip
+### Update from source
 
 ```bash
-pip install --upgrade hermes-agent
+cd ~/hermes-agent
+git pull
+python -m pip install -e '.[termux]' -c constraints-termux.txt
 ```
 
 ### Update configuration

--- a/hermes/README.md
+++ b/hermes/README.md
@@ -29,6 +29,8 @@ Xander is a conversational AI companion optimized for voice interaction, especia
 
 ### Step 1: Install Hermes Agent
 
+**⚠️ Important:** Hermes is NOT on PyPI - must install from source.
+
 ```bash
 # Update packages
 pkg update && pkg upgrade
@@ -36,12 +38,17 @@ pkg update && pkg upgrade
 # Install Python and dependencies
 pkg install python python-pip git
 
-# Install Hermes Agent
-pip install hermes-agent
-
-# OR install from source for latest features
+# Install Hermes Agent (official install script - Recommended)
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+source ~/.bashrc
+
+# OR Manual Termux installation
+git clone https://github.com/NousResearch/hermes-agent.git
+cd hermes-agent
+python -m pip install -e '.[termux]' -c constraints-termux.txt
 ```
+
+> **⚠️ Termux Note:** Use `[termux]` extra, NOT `[all]`. The `[all]` extra pulls Android-incompatible dependencies (ctranslate2, onnxruntime).
 
 ### Step 2: Set Up Configuration
 


### PR DESCRIPTION
## Summary

This PR fixes the incorrect Hermes installation instructions in the documentation. The current docs recommend `pip install hermes-agent`, but **Hermes is NOT published to PyPI**.

## Changes Made

### `docs/hermes/setup.md`
- **Step 2: Install Hermes Agent**
  - Added warning: "⚠️ Important: Hermes is NOT on PyPI - must install from source"
  - Changed Option A to "Official Install Script (Recommended)" with curl command
  - Added Option B "Manual Termux Installation" with uv and pip install from source
  - Added Option C "Using setup-hermes.sh Script"
  - Added Termux-specific note about `[termux]` extra vs `[all]`

- **Troubleshooting Section**
  - Added new entry for "hermes-agent not found on PyPI"
  - Updated "Command not found: hermes" to remove `pip show hermes-agent` reference

- **Updating Hermes Section**
  - Changed from `pip install --upgrade hermes-agent` to git-based update

### `hermes/README.md`
- **Step 1: Install Hermes Agent**
  - Removed the incorrect `pip install hermes-agent` command
  - Added prominent warning that Hermes is NOT on PyPI
  - Added official install script method as recommended approach
  - Added manual Termux installation with git clone
  - Added Termux-specific note about using `[termux]` extra instead of `[all]`

## Acceptance Criteria (from Issue #36)

- [x] `docs/hermes/setup.md` has correct installation instructions
- [x] No references to `pip install hermes-agent` remain in documentation
- [x] Termux-specific notes are included (`[termux]` extra, not `[all]`)
- [x] Troubleshooting section updated
- [x] Instructions match Issue #19 guidance
- [x] `hermes/README.md` installation instructions match the main setup docs

## Related

- Fixes #36
- References #19 (original installation guidance)
- Part of Epic #35 (Complete Hermes Migration)