### PR TITLE
fix: Standardize Port Configuration Across Codebase (8080 vs 3000) (#37)

### DIFF
--- a/docs/hermes/configuration.md
+++ b/docs/hermes/configuration.md
@@ -27,6 +27,25 @@ model: anthropic/claude-sonnet-4-20250514
 - Use `anthropic/claude-3-haiku-20240307` for faster, cheaper responses
 - See [OpenRouter Models](https://openrouter.ai/models) for all options
 
+### Server Configuration
+
+```yaml
+# Server Configuration
+server:
+  port: 8080
+  host: "127.0.0.1"
+```
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `port` | Port number for Hermes HTTP server | `8080` |
+| `host` | Host address to bind to | `127.0.0.1` |
+
+**Server Configuration Notes:**
+- Default port 8080 is used by the mobile app
+- Use `127.0.0.1` for local-only access (recommended for mobile integration)
+- Can be overridden with `hermes serve --port <port>` command
+
 ### Response Settings
 
 ```yaml

--- a/docs/hermes/setup.md
+++ b/docs/hermes/setup.md
@@ -263,7 +263,7 @@ For persistent operation, create a Termux service:
 cat > ~/start-hermes.sh << 'EOF'
 #!/bin/bash
 cd ~
-hermes serve --port 3000
+hermes serve --port 8080
 EOF
 
 chmod +x ~/start-hermes.sh
@@ -303,7 +303,7 @@ Once Hermes is running, the React Native mobile app communicates via HTTP:
 ```
 Mobile App (React Native)
     │
-    │ HTTP (localhost:3000)
+    │ HTTP (localhost:8080)
     ▼
 Hermes Agent (Termux)
 ```

--- a/hermes/config.yaml
+++ b/hermes/config.yaml
@@ -6,6 +6,11 @@
 # Using OpenRouter for flexibility with multiple providers
 model: anthropic/claude-sonnet-4-20250514
 
+# Server Configuration
+server:
+  port: 8080
+  host: "127.0.0.1"
+
 # Response settings optimized for voice/TTS
 # Keep responses short and natural for spoken output
 tool_output:


### PR DESCRIPTION
## Summary

This PR standardizes the port configuration across the codebase to use **port 8080** for Hermes API endpoint, resolving the inconsistency identified in issue #37.

## Problem

The codebase had inconsistent port configuration for the Hermes API endpoint:

| Location | Previous Port | Current Port |
|----------|--------------|--------------|
| `mobile/src/api/xanderApi.ts` | 8080 ✓ | 8080 ✓ |
| `docs/hermes/README.md` | 8080 ✓ | 8080 ✓ |
| `docs/hermes/setup.md` (service script) | ~~3000~~ | **8080** ✓ |
| `docs/hermes/setup.md` (integration diagram) | ~~3000~~ | **8080** ✓ |
| `hermes/config.yaml` | Not set | **8080** ✓ |
| `docs/hermes/configuration.md` | Not documented | **Documented** ✓ |

## Changes Made

### 1. `hermes/config.yaml`
Added explicit server port configuration:
```yaml
# Server Configuration
server:
  port: 8080
  host: "127.0.0.1"
```

### 2. `docs/hermes/setup.md`
- Updated service script from `hermes serve --port 3000` to `hermes serve --port 8080`
- Updated integration diagram from `HTTP (localhost:3000)` to `HTTP (localhost:8080)`
- **Note:** Silas workstation references (port 3000) were intentionally NOT changed

### 3. `docs/hermes/configuration.md`
Added new **Server Configuration** section documenting the server settings with configuration table and usage notes.

## Acceptance Criteria

- [x] All documentation references same port (8080 for Hermes)
- [x] `hermes/config.yaml` has explicit port setting
- [x] `mobile/src/api/xanderApi.ts` matches documentation
- [x] Setup guide uses correct port in all examples
- [x] Port configuration is documented in configuration reference

## Testing Steps

1. Start Hermes: `hermes serve --port 8080`
2. Test health: `curl http://localhost:8080/health`
3. Test mobile connection in React Native app

Closes #37