### PR TITLE
Enable Silas MCP Integration in Hermes Config (#38)

### DIFF
--- a/docs/hermes/configuration.md
+++ b/docs/hermes/configuration.md
@@ -140,37 +140,55 @@ agent:
 
 ### MCP Servers Configuration
 
+The Silas MCP integration is now enabled by default with environment variable configuration:
+
 ```yaml
 mcp_servers:
-  # Silas dispatch server
-  # silas:
-  #   url: "http://workstation-ip:3000"
-  #   tools:
-  #     include: [dispatch_task, check_task_status, list_pending_tasks]
-  #     prompts: false
-  #     resources: false
+  # Silas dispatch server for task execution on workstation
+  silas:
+    # Environment variable for workstation URL (configure in .env)
+    url: "${SILAS_MCP_URL}"
+    tools:
+      include:
+        - dispatch_task
+        - task_status
+        - list_tasks
+        - cancel_task
+        - queue_stats
+      prompts: false
+      resources: false
 ```
 
 | Setting | Description | Notes |
 |---------|-------------|-------|
-| `url` | MCP server endpoint | Replace with actual Silas IP |
-| `tools.include` | Allowed tools | Whitelist specific tools |
-| `prompts` | Enable MCP prompts | Usually `false` for dispatch |
-| `resources` | Enable MCP resources | Usually `false` for dispatch |
+| `url` | MCP server endpoint | Uses `SILAS_MCP_URL` env var |
+| `tools.include` | Allowed tools | Whitelist of Silas tools |
+| `prompts` | Enable MCP prompts | `false` for dispatch-only usage |
+| `resources` | Enable MCP resources | `false` for dispatch-only usage |
 
-**Enabling Silas Dispatch:**
+**Available Silas Tools:**
 
-1. Uncomment the `silas` section
-2. Replace `workstation-ip:3000` with actual IP
-3. Ensure Silas MCP server is running
+| Tool | Description |
+|------|-------------|
+| `dispatch_task` | Create and queue a new task |
+| `task_status` | Check status of a specific task |
+| `list_tasks` | List all tasks (optionally filtered by status) |
+| `cancel_task` | Cancel a pending task |
+| `queue_stats` | Get queue statistics |
 
-```yaml
-mcp_servers:
-  silas:
-    url: "http://192.168.1.100:3000"
-    tools:
-      include: [dispatch_task, check_task_status, list_pending_tasks]
+**Configuring Silas URL:**
+
+Set the `SILAS_MCP_URL` environment variable in `~/.hermes/.env`:
+
+```bash
+# Local network example
+SILAS_MCP_URL=http://192.168.1.100:3000
+
+# Tailscale example (recommended for remote access)
+SILAS_MCP_URL=http://100.x.x.x:3000
 ```
+
+See [Silas Workstation Setup](../silas-workstation/setup.md#network-configuration) for network configuration details.
 
 ### File Read Safety
 
@@ -251,14 +269,24 @@ Details: <detailed description>
 
 ## Environment Variables
 
-Create `~/.hermes/.env` with API keys:
+Create `~/.hermes/.env` with API keys and configuration. You can copy the template from the repository:
 
 ```bash
-# Required: LLM Provider
-OPENROUTER_API_KEY=sk-or-your-key-here
+cp ~/autoxan/hermes/.env.example ~/.hermes/.env
+```
 
-# Alternative: Direct Anthropic
+Then edit with your actual values:
+
+```bash
+# Required: LLM Provider (choose one)
+OPENROUTER_API_KEY=sk-or-your-key-here
 # ANTHROPIC_API_KEY=sk-ant-your-key-here
+
+# Silas Workstation MCP Server
+# Replace with your workstation's actual IP address
+# Local network: http://192.168.1.100:3000
+# Tailscale: http://100.x.x.x:3000
+SILAS_MCP_URL=http://192.168.1.100:3000
 
 # Optional: GitHub integration
 # GITHUB_TOKEN=ghp_your-token-here
@@ -268,9 +296,12 @@ OPENROUTER_API_KEY=sk-or-your-key-here
 |----------|----------|-------------|
 | `OPENROUTER_API_KEY` | Yes* | OpenRouter API key |
 | `ANTHROPIC_API_KEY` | Yes* | Direct Anthropic API key |
+| `SILAS_MCP_URL` | Yes** | Silas workstation URL (e.g., `http://192.168.1.100:3000`) |
 | `GITHUB_TOKEN` | No | For GitHub MCP integration |
 
 *One of `OPENROUTER_API_KEY` or `ANTHROPIC_API_KEY` is required.
+
+**Required if using Silas dispatch. See [Network Configuration](../silas-workstation/setup.md#network-configuration) for setup instructions.
 
 ## Voice-Optimized Settings Summary
 

--- a/docs/hermes/setup.md
+++ b/docs/hermes/setup.md
@@ -99,24 +99,40 @@ cp ~/autoxan/hermes/SOUL.md ~/.hermes/SOUL.md
 cp ~/autoxan/hermes/config.yaml ~/.hermes/config.yaml
 ```
 
-### Step 6: Configure API Keys
+### Step 6: Configure Environment Variables
 
-Create the environment file:
+Copy the environment template and configure your settings:
+
+```bash
+# Copy the template
+cp ~/autoxan/hermes/.env.example ~/.hermes/.env
+
+# Edit with your values
+nano ~/.hermes/.env
+```
+
+Or create manually:
 
 ```bash
 cat > ~/.hermes/.env << 'EOF'
-# OpenRouter API key (recommended)
+# Required: LLM Provider (choose one)
 OPENROUTER_API_KEY=sk-or-your-key-here
-
-# OR use Anthropic directly
 # ANTHROPIC_API_KEY=sk-ant-your-key-here
+
+# Silas Workstation MCP Server
+# Replace with your workstation's actual IP address
+# Local network: http://192.168.1.100:3000
+# Tailscale: http://100.x.x.x:3000
+SILAS_MCP_URL=http://192.168.1.100:3000
 
 # Optional: GitHub token for code search
 # GITHUB_TOKEN=ghp_your-token-here
 EOF
 ```
 
-**Important:** Replace `sk-or-your-key-here` with your actual API key.
+**Important:**
+- Replace `sk-or-your-key-here` with your actual OpenRouter or Anthropic API key
+- Replace the `SILAS_MCP_URL` with your workstation's IP address (see [Network Configuration](../silas-workstation/setup.md#network-configuration))
 
 ### Step 7: Verify Installation
 
@@ -318,8 +334,18 @@ After setup, your Hermes configuration should look like:
 ~/.hermes/
 ├── config.yaml     # Hermes settings
 ├── SOUL.md         # Xander personality
-├── .env            # API keys (not in git)
+├── .env            # API keys and SILAS_MCP_URL (not in git)
 └── memory/         # Persistent memory (auto-created)
+```
+
+The Autoxan repository provides templates:
+
+```
+~/autoxan/hermes/
+├── config.yaml     # Configuration template
+├── SOUL.md         # Xander personality definition
+├── .env.example    # Environment variable template
+└── README.md       # Quick start guide
 ```
 
 ## Related Documentation

--- a/docs/silas-workstation/setup.md
+++ b/docs/silas-workstation/setup.md
@@ -142,24 +142,36 @@ Future versions may support:
 
 ### Connecting to Xander (Hermes)
 
-Silas Workstation uses stdio transport by default. To connect from Hermes:
+Silas Workstation provides an HTTP-based MCP server. To connect from Hermes:
 
-1. **Configure Hermes MCP** in `/hermes/config.yaml`:
+1. **Configure Hermes MCP** in `~/.hermes/config.yaml` (already enabled by default):
 
 ```yaml
-mcp:
-  servers:
-    silas:
-      command: "node"
-      args: 
-        - "/path/to/silas-workstation/dist/index.js"
+mcp_servers:
+  silas:
+    url: "${SILAS_MCP_URL}"
+    tools:
+      include:
+        - dispatch_task
+        - task_status
+        - list_tasks
+        - cancel_task
+        - queue_stats
+      prompts: false
+      resources: false
 ```
 
-2. **Test the connection** by sending a task from Xander.
+2. **Set the SILAS_MCP_URL** in `~/.hermes/.env`:
+
+```bash
+SILAS_MCP_URL=http://192.168.1.100:3000
+```
+
+3. **Test the connection** by sending a task from Xander.
 
 ### Testing MCP Tools Manually
 
-You can test the MCP server manually using the MCP CLI or by sending JSON-RPC messages via stdin.
+You can test the MCP server manually using the MCP CLI or by sending JSON-RPC messages.
 
 Example dispatch_task request:
 ```json
@@ -177,6 +189,155 @@ Example dispatch_task request:
   }
 }
 ```
+
+## Network Configuration
+
+To enable Hermes (running on your phone) to communicate with Silas Workstation, you need to configure network connectivity.
+
+### Finding Your Workstation IP Address
+
+**Linux:**
+```bash
+# Using ip command
+ip addr show | grep "inet "
+
+# Or using hostname
+hostname -I
+```
+
+**macOS:**
+```bash
+# Show network interfaces
+ifconfig | grep "inet "
+
+# Or use system preferences
+networksetup -getinfo Wi-Fi
+```
+
+**Windows:**
+```powershell
+# Using PowerShell
+Get-NetIPAddress -AddressFamily IPv4 | Select IPAddress
+```
+
+Look for an IP address like `192.168.1.x` or `10.0.0.x` for local network.
+
+### Local Network Setup
+
+For phone and workstation on the **same network** (home WiFi):
+
+1. **Find workstation IP** using commands above
+2. **Configure firewall** to allow port 3000:
+
+   **Linux (ufw):**
+   ```bash
+   sudo ufw allow 3000/tcp
+   sudo ufw reload
+   ```
+
+   **Linux (firewalld):**
+   ```bash
+   sudo firewall-cmd --add-port=3000/tcp --permanent
+   sudo firewall-cmd --reload
+   ```
+
+   **macOS:**
+   ```bash
+   # Open System Preferences > Security & Privacy > Firewall
+   # Add exception for port 3000 or disable during development
+   ```
+
+3. **Set SILAS_MCP_URL** in `~/.hermes/.env`:
+   ```bash
+   SILAS_MCP_URL=http://192.168.1.100:3000
+   ```
+
+4. **Verify connectivity** from phone terminal (Termux):
+   ```bash
+   curl http://192.168.1.100:3000/health
+   ```
+
+### Tailscale Setup (Recommended for Remote Access)
+
+[Tailscale](https://tailscale.com/) provides secure, zero-config networking. This is the recommended approach for:
+- Remote access from outside your home network
+- Avoiding firewall/port forwarding complexity
+- Secure encrypted connection
+
+**Step 1: Install Tailscale on Workstation**
+
+**Linux:**
+```bash
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up
+```
+
+**macOS:**
+```bash
+brew install --cask tailscale
+# Or download from https://tailscale.com/download
+```
+
+**Step 2: Install Tailscale on Android**
+
+1. Install Tailscale from Google Play Store
+2. Sign in with same account as workstation
+3. Enable VPN when prompted
+
+**Step 3: Get Tailscale IP**
+
+On your workstation:
+```bash
+tailscale ip -4
+# Example output: 100.64.123.45
+```
+
+Or check the Tailscale admin console at [login.tailscale.com](https://login.tailscale.com).
+
+**Step 4: Configure Hermes**
+
+Update `~/.hermes/.env` with Tailscale IP:
+```bash
+SILAS_MCP_URL=http://100.64.123.45:3000
+```
+
+**Step 5: Verify Connection**
+
+From phone (with Tailscale connected):
+```bash
+curl http://100.64.123.45:3000/health
+```
+
+### Verifying Connectivity
+
+Test the connection from your phone (Termux):
+
+```bash
+# Test basic connectivity
+ping -c 3 <WORKSTATION_IP>
+
+# Test HTTP endpoint
+curl -v http://<WORKSTATION_IP>:3000/health
+
+# Test MCP tool (if server is running)
+curl -X POST http://<WORKSTATION_IP>:3000 \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+**Expected responses:**
+- Ping: 3 successful replies
+- Health check: `{"status":"ok"}` or similar
+- Tools list: JSON-RPC response with available tools
+
+### Common Network Issues
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| Connection refused | Firewall blocking | Open port 3000 |
+| No route to host | Different networks | Use Tailscale |
+| Timeout | IP address wrong | Verify workstation IP |
+| Name resolution fail | Using hostname instead of IP | Use IP address directly |
 
 ## Project Scripts
 

--- a/hermes/.env.example
+++ b/hermes/.env.example
@@ -1,0 +1,15 @@
+# Hermes Environment Configuration
+# Copy to ~/.hermes/.env on your device and fill in values
+
+# Required: LLM Provider (choose one)
+OPENROUTER_API_KEY=sk-or-your-key-here
+# ANTHROPIC_API_KEY=sk-ant-your-key-here
+
+# Silas Workstation MCP Server
+# Replace with your workstation's actual IP address
+# Local network: http://192.168.1.100:3000
+# Tailscale: http://100.x.x.x:3000
+SILAS_MCP_URL=http://192.168.1.100:3000
+
+# Optional: GitHub integration
+# GITHUB_TOKEN=ghp_your-token-here

--- a/hermes/SOUL.md
+++ b/hermes/SOUL.md
@@ -30,6 +30,24 @@ Details: <detailed description of what needs to be done>
 [/DISPATCH_SUGGESTED]
 ```
 
+## Using MCP Tools for Dispatch
+
+When the user confirms they want to dispatch a task to Silas, use the `dispatch_task` MCP tool directly. The tool accepts:
+
+- **type**: One of `code`, `research`, `file`, or `general`
+- **description**: Detailed description of what needs to be done
+- **priority**: One of `high`, `normal`, or `low` (default: normal)
+- **context**: Optional additional context for the task
+- **metadata**: Optional metadata for tracking
+
+Other available MCP tools:
+- `task_status`: Check the status of a dispatched task by ID
+- `list_tasks`: List tasks with optional filtering
+- `cancel_task`: Cancel a pending task
+- `queue_stats`: Get overall queue statistics
+
+When dispatching, provide clear, actionable descriptions that Silas can execute.
+
 ## Response Guidelines
 - Keep responses concise (1-3 sentences for simple exchanges)
 - Be natural in conversation - use contractions, casual language

--- a/hermes/config.yaml
+++ b/hermes/config.yaml
@@ -53,13 +53,19 @@ agent:
 # MCP Servers Configuration
 # For dispatch to Silas workstation agent
 mcp_servers:
-  # Silas dispatch server (configure when Silas MCP is available)
-  # silas:
-  #   url: "http://workstation-ip:3000"  # Replace with actual Silas endpoint
-  #   tools:
-  #     include: [dispatch_task, check_task_status, list_pending_tasks]
-  #     prompts: false
-  #     resources: false
+  # Silas dispatch server for task execution on workstation
+  silas:
+    # Environment variable for workstation URL (configure in .env)
+    url: "${SILAS_MCP_URL}"
+    tools:
+      include:
+        - dispatch_task
+        - task_status
+        - list_tasks
+        - cancel_task
+        - queue_stats
+      prompts: false
+      resources: false
   
   # Example: GitHub integration for light research
   # github:


### PR DESCRIPTION
## Summary

This PR enables true MCP protocol dispatch from Xander (via Hermes) to the Silas workstation agent.

**Fixes:** #38
**Epic:** #35 - Complete Hermes Migration
**Depends On:** #37 (Port Standardization) ✅

## Problem Solved

The Hermes configuration had the Silas MCP server integration **commented out**, meaning:
- Dispatch from Xander to Silas didn't use true MCP protocol
- The mobile app's dispatch function just sent a chat message
- Tasks weren't properly routed to the silas-workstation MCP server

## Changes

### Implementation Changes
| File | Change |
|------|--------|
| `hermes/config.yaml` | Enabled and configured `mcp_servers.silas` with correct tool whitelist |
| `hermes/.env.example` | **New file** - Environment variable template with `SILAS_MCP_URL` |
| `hermes/SOUL.md` | Added MCP dispatch instructions for Xander |

### Documentation Changes
| File | Change |
|------|--------|
| `docs/hermes/configuration.md` | Updated MCP Servers Configuration section with enabled config, added SILAS_MCP_URL to environment variables |
| `docs/hermes/setup.md` | Updated environment variable configuration to reference `.env.example` |
| `docs/silas-workstation/setup.md` | Added comprehensive Network Configuration section (local network, firewall, Tailscale) |

## Configuration Details

### MCP Server Configuration (config.yaml)
```yaml
mcp_servers:
  silas:
    url: "${SILAS_MCP_URL}"
    tools:
      include:
        - dispatch_task
        - task_status
        - list_tasks
        - cancel_task
        - queue_stats
      prompts: false
      resources: false
```

### Environment Variable (.env.example)
```bash
SILAS_MCP_URL=http://192.168.1.100:3000
```

## Acceptance Criteria Checklist

- [x] MCP server configuration is enabled in config.yaml
- [x] SILAS_MCP_URL environment variable documented
- [x] Hermes can call `dispatch_task` tool (configuration complete)
- [x] Documentation updated for MCP setup
- [x] Network configuration documentation added

## Testing Notes

After merging, to enable MCP dispatch:

1. **Start silas-workstation:**
   ```bash
   cd silas-workstation && npm start
   ```

2. **Configure environment:**
   ```bash
   # Copy and edit .env on device
   cp hermes/.env.example ~/.hermes/.env
   # Set SILAS_MCP_URL to your workstation IP
   ```

3. **Start Hermes:**
   ```bash
   hermes serve --port 8080
   ```

4. **Test dispatch via Xander:**
   ```
   "Dispatch a task to Silas: Create a README file"
   ```

## Stats

```
6 files changed, 306 insertions(+), 49 deletions(-)
```